### PR TITLE
 Fix helper wage suppression and active worker detectio

### DIFF
--- a/modDesc.xml
+++ b/modDesc.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" standalone="no" ?>
 <modDesc descVersion="92">
     <author>TisonK</author>
-    <version>1.0.4.0</version>
+    <version>1.0.6.0</version>
     <modName>FS25_WorkerCostsMod</modName>
     <title>
         <en>Realistic Worker Costs</en>

--- a/src/WorkerSystem.lua
+++ b/src/WorkerSystem.lua
@@ -47,6 +47,10 @@ end
 
 function WorkerSystem:initialize()
     if self.isInitialized then
+        -- Re-install the hook in case it was lost (e.g. after WorkerCostsEnable)
+        if not self._hookedAddMoney then
+            self:installGameHook()
+        end
         return
     end
 
@@ -57,7 +61,7 @@ function WorkerSystem:initialize()
         self:installGameHook()
 
         self.isInitialized = true
-        self:log("Worker System initialized. Mode: %s, Base Rate: $%d",
+        Logging.info("[Worker Costs] Worker System initialized. Mode: %s, Base Rate: $%d",
             self.settings:getCostModeName(), self.settings:getWageRate())
     end
 end
@@ -76,7 +80,11 @@ end
 
 --- Patch mission.addMoney to zero out the game's own worker-wage deductions.
 -- We use _isProcessingPayment as a flag so that OUR payments still pass through.
--- Only negative addMoney calls are intercepted; positive calls are always allowed.
+--
+-- IMPORTANT: The game charges helper wages via MoneyType.AI (confirmed from AIJob source).
+-- AIJob:updateCost() accumulates pendingCost and flushes whenever it exceeds 25§:
+--   g_currentMission:addMoney(-self.pendingCost, self.startedFarmId, MoneyType.AI, true)
+-- We intercept exactly MoneyType.AI charges while helpers are active.
 function WorkerSystem:installGameHook()
     if not g_currentMission then
         return
@@ -91,28 +99,58 @@ function WorkerSystem:installGameHook()
         return
     end
 
-    -- Capture self in the closure so the hook survives reassignment of any
-    -- module-level variable and cleans up correctly via delete().
-    local capturedSelf = self
-    self._originalAddMoney = originalAddMoney
+    -- MoneyType.AI is the type used by AIJob:updateCost() and AIJob:stop().
+    -- Log whatever values are available so the diagnostic command can report them.
+    local aiMoneyType = MoneyType and MoneyType.AI
+    Logging.info("[Worker Costs] MoneyType.AI = %s, MoneyType.WORKER_WAGES = %s",
+        tostring(aiMoneyType),
+        tostring(MoneyType and MoneyType.WORKER_WAGES))
+
+    if aiMoneyType == nil then
+        Logging.warning("[Worker Costs] MoneyType.AI not found — will fall back to active-job heuristic.")
+    end
+
+    local capturedSelf      = self
+    local capturedAIType    = aiMoneyType
+    self._originalAddMoney  = originalAddMoney
 
     mission.addMoney = function(missionObj, amount, farmId, moneyType, ...)
-        -- Only intercept the game's own worker-wage deductions (MoneyType.WORKER_WAGES).
-        -- All other negative calls (equipment purchases, repairs, etc.) must pass through.
-        -- When _isProcessingPayment is true the call originated from our chargeWage(),
-        -- so we let it through regardless.
-        if capturedSelf.settings.enabled
-                and amount < 0
-                and moneyType == MoneyType.WORKER_WAGES
-                and not capturedSelf._isProcessingPayment then
-            capturedSelf:log("Suppressed built-in worker payment: %d (moneyType=%s)", amount, tostring(moneyType))
-            return
+        -- Let OUR charges pass through unconditionally.
+        if capturedSelf._isProcessingPayment then
+            return originalAddMoney(missionObj, amount, farmId, moneyType, ...)
         end
+
+        if capturedSelf.settings.enabled and amount < 0 then
+            -- Primary: MoneyType.AI is what AIJob uses for helper wages.
+            local isHelperWage = (capturedAIType ~= nil and moneyType == capturedAIType)
+
+            -- Also catch MoneyType.WORKER_WAGES in case some FS25 builds use it.
+            if not isHelperWage and MoneyType and MoneyType.WORKER_WAGES ~= nil then
+                isHelperWage = (moneyType == MoneyType.WORKER_WAGES)
+            end
+
+            -- Fallback when MoneyType enum is unavailable: intercept small negative
+            -- charges that coincide with active AI jobs (AIJob flushes at >25§ chunks).
+            if not isHelperWage and capturedAIType == nil then
+                local hasActiveJobs = false
+                local aiSystem = g_currentMission and g_currentMission.aiSystem
+                if aiSystem and aiSystem.activeJobs then
+                    hasActiveJobs = (#aiSystem.activeJobs > 0)
+                end
+                isHelperWage = hasActiveJobs and math.abs(amount) <= 500
+            end
+
+            if isHelperWage then
+                capturedSelf:log("Suppressed built-in helper wage: %d (moneyType=%s)", amount, tostring(moneyType))
+                return
+            end
+        end
+
         return originalAddMoney(missionObj, amount, farmId, moneyType, ...)
     end
 
     self._hookedAddMoney = true
-    self:log("Installed hook to suppress built-in worker costs")
+    Logging.info("[Worker Costs] Hook installed — intercepting MoneyType.AI helper wages")
 end
 
 function WorkerSystem:log(msg, ...)
@@ -145,15 +183,42 @@ function WorkerSystem:getActiveWorkers()
         return workers
     end
 
-    for _, job in pairs(aiSystem.activeJobs) do
-        if job and job.isActive and job.vehicle then
-            -- getFullName may not exist on all vehicle types; guard the call
-            local name = (job.vehicle.getFullName and job.vehicle:getFullName()) or "Worker"
-            table.insert(workers, {
-                vehicle = job.vehicle,
-                job = job,
-                name = name
-            })
+    -- activeJobs is an array — use ipairs, not pairs.
+    -- job.isRunning is the correct running-state field (not job.isActive).
+    -- Vehicle is accessed via job.vehicleParameter:getVehicle() on field-work jobs,
+    -- with a fallback to job.vehicle for any custom job types that set it directly.
+    for _, job in ipairs(aiSystem.activeJobs) do
+        if job and job.isRunning then
+            -- Get vehicle: prefer the official vehicleParameter API
+            local vehicle = nil
+            if job.vehicleParameter and job.vehicleParameter.getVehicle then
+                vehicle = job.vehicleParameter:getVehicle()
+            elseif job.vehicle then
+                vehicle = job.vehicle
+            end
+
+            if vehicle then
+                -- Helper name: job:getHelperName() is defined on AIJob base class
+                local name = "Worker"
+                if job.getHelperName then
+                    local ok, helperName = pcall(function() return job:getHelperName() end)
+                    if ok and helperName and helperName ~= "" then
+                        name = helperName
+                    end
+                end
+                -- Fall back to vehicle name if helper name unavailable
+                if name == "Worker" then
+                    name = (vehicle.getFullName and vehicle:getFullName())
+                       or (vehicle.getName and vehicle:getName())
+                       or "Worker"
+                end
+
+                table.insert(workers, {
+                    vehicle = vehicle,
+                    job     = job,
+                    name    = name
+                })
+            end
         end
     end
 

--- a/src/main.lua
+++ b/src/main.lua
@@ -1,5 +1,5 @@
 -- =========================================================
--- FS25 Realistic Worker Costs Mod (version 1.0.4.0)
+-- FS25 Realistic Worker Costs Mod (version 1.0.6.0)
 -- =========================================================
 -- Hourly or per-hectare wages for workers
 -- =========================================================
@@ -142,4 +142,4 @@ end
 getfenv(0)["workerCosts"]       = workerCosts
 getfenv(0)["workerCostsStatus"] = workerCostsStatus
 
-Logging.info("[Worker Costs] v1.0.4.0 loaded — type 'workerCosts' in console for help")
+Logging.info("[Worker Costs] v1.0.6.0 loaded — type 'workerCosts' in console for help")

--- a/src/settings/WorkerSettingsGUI.lua
+++ b/src/settings/WorkerSettingsGUI.lua
@@ -29,11 +29,13 @@ function WorkerSettingsGUI:registerConsoleCommands()
     addConsoleCommand("WorkerCostsSetNotifications", "Enable/disable notifications (true/false)", "consoleCommandSetNotifications", self)
     addConsoleCommand("WorkerCostsSetCustomRate", "Set custom wage rate (0 = use wage level)", "consoleCommandSetCustomRate", self)
     addConsoleCommand("WorkerCostsTestPayment", "Test wage payment system", "consoleCommandTestPayment", self)
+    addConsoleCommand("WorkerCostsDebug", "Enable/disable debug mode (true/false)", "consoleCommandSetDebug", self)
 
     addConsoleCommand("WorkerCostsMonthlySalary", "Enable/disable monthly salary dialog (true/false)", "consoleCommandSetMonthlySalary", self)
     addConsoleCommand("WorkerCostsTestMonthlySalary", "Trigger monthly salary dialog right now (for testing)", "consoleCommandTestMonthlySalary", self)
     
     addConsoleCommand("WorkerCostsShowSettings", "Show current settings", "consoleCommandShowSettings", self)
+    addConsoleCommand("WorkerCostsDiagnostic", "Run full diagnostic report", "consoleCommandDiagnostic", self)
     
     addConsoleCommand("WorkerCostsResetSettings", "Reset all settings to defaults", "consoleCommandResetSettings", self)
     
@@ -52,7 +54,9 @@ function WorkerSettingsGUI:consoleCommandHelp()
     print("WorkerCostsSetNotifications true|false - Toggle notifications")
     print("WorkerCostsSetCustomRate <rate> - Set custom rate (0 for default)")
     print("WorkerCostsTestPayment - Test payment system")
+    print("WorkerCostsDebug true|false - Toggle debug logging")
     print("WorkerCostsShowSettings - Show current settings")
+    print("WorkerCostsDiagnostic - Run full diagnostic report")
     print("WorkerCostsResetSettings - Reset to defaults")
     print("===========================================")
     return "Type 'workerCosts' for more info"
@@ -196,6 +200,82 @@ function WorkerSettingsGUI:consoleCommandShowSettings()
     end
 
     return "Error: Worker Costs Mod not initialized"
+end
+
+function WorkerSettingsGUI:consoleCommandSetDebug(valueStr)
+    if g_WorkerManager and g_WorkerManager.settings then
+        local value = (valueStr == "true" or valueStr == "1")
+        g_WorkerManager.settings.debugMode = value
+        g_WorkerManager.settings:save()
+        return string.format("Debug mode %s", value and "ENABLED — check log.txt for [Worker Costs] entries" or "DISABLED")
+    end
+    return "Error: Worker Costs Mod not initialized"
+end
+
+function WorkerSettingsGUI:consoleCommandDiagnostic()
+    local lines = { "=== Worker Costs Mod Diagnostic ===" }
+
+    -- 1. Manager
+    if g_WorkerManager == nil then
+        table.insert(lines, "FAIL: g_WorkerManager is nil — mod did not initialize!")
+        print(table.concat(lines, "\n"))
+        return table.concat(lines, "\n")
+    end
+    table.insert(lines, "OK:   g_WorkerManager exists")
+
+    -- 2. Settings
+    local settings = g_WorkerManager.settings
+    if settings == nil then
+        table.insert(lines, "FAIL: settings is nil")
+    else
+        table.insert(lines, string.format("OK:   settings — enabled=%s, mode=%s, rate=$%d, debug=%s",
+            tostring(settings.enabled), settings:getCostModeName(),
+            settings:getWageRate(), tostring(settings.debugMode)))
+    end
+
+    -- 3. WorkerSystem
+    local ws = g_WorkerManager.workerSystem
+    if ws == nil then
+        table.insert(lines, "FAIL: workerSystem is nil")
+    else
+        table.insert(lines, string.format("OK:   workerSystem — initialized=%s, hookInstalled=%s",
+            tostring(ws.isInitialized), tostring(ws._hookedAddMoney)))
+    end
+
+    -- 4. Mission / addMoney hook
+    if g_currentMission then
+        local isHooked = ws and ws._hookedAddMoney
+        table.insert(lines, string.format("%s:  addMoney hook — %s",
+            isHooked and "OK  " or "WARN",
+            isHooked and "installed" or "NOT installed (built-in wages may still run!)"))
+    else
+        table.insert(lines, "WARN: g_currentMission is nil — not in a game?")
+    end
+
+    -- 5. MoneyType check
+    local aiType  = MoneyType and MoneyType.AI
+    local wageType = MoneyType and MoneyType.WORKER_WAGES
+    table.insert(lines, string.format("%s:  MoneyType.AI = %s (this is what the game uses for helper wages)",
+        aiType ~= nil and "OK  " or "WARN", tostring(aiType)))
+    table.insert(lines, string.format("INFO: MoneyType.WORKER_WAGES = %s", tostring(wageType)))
+
+    -- 6. Active workers
+    if ws then
+        local workers = ws:getActiveWorkers()
+        table.insert(lines, string.format("INFO: Active workers detected: %d", #workers))
+        for _, w in ipairs(workers) do
+            table.insert(lines, string.format("      - %s", w.name))
+        end
+    end
+
+    -- 7. GUI
+    table.insert(lines, string.format("INFO: g_wcModGui=%s, g_wcGui=%s, g_inGameMenu=%s",
+        tostring(g_wcModGui ~= nil), tostring(g_wcGui ~= nil), tostring(g_inGameMenu ~= nil)))
+
+    table.insert(lines, "=== End Diagnostic ===")
+    local report = table.concat(lines, "\n")
+    print(report)
+    return report
 end
 
 function WorkerSettingsGUI:consoleCommandResetSettings()


### PR DESCRIPTION
### Problem
Two bugs prevented the mod from working correctly:

- The game's built-in helper wages (25§ deducted per interval) were never suppressed. The hook was checking for `MoneyType.WORKER_WAGES`, but FS25's `AIJob:updateCost()` actually uses `MoneyType.AI`. The enum value `WORKER_WAGES` does not exist in FS25, so every built-in deduction passed through unchecked.
- The pause menu showed nothing because `getActiveWorkers()` used incorrect field names and access patterns. `job.isActive` does not exist (should be `job.isRunning`), `job.vehicle` is not set on field work jobs (should be `job.vehicleParameter:getVehicle()`), and `activeJobs` is an array that must be iterated with `ipairs()`, not `pairs()`.

Both issues were confirmed against the official FS25 community Lua documentation (`AIJob`, `AIJobFieldWork`, `AISystem`).

### Changes
**`src/WorkerSystem.lua`**
- `installGameHook()`: intercept `MoneyType.AI` as primary target; retain `MoneyType.WORKER_WAGES` and active-job heuristic as fallbacks
- `initialize()`: re-installs hook if `_hookedAddMoney` is false even when already initialized
- `getActiveWorkers()`: rewritten with correct FS25 API (`job.isRunning`, `vehicleParameter:getVehicle()`, `job:getHelperName()`, `ipairs()`)

**`src/settings/WorkerSettingsGUI.lua`**
- Added `WorkerCostsDebug true|false` console command to toggle debug logging at runtime
- Added `WorkerCostsDiagnostic` console command for a full status report (hook installed, MoneyType values, active workers)

### Testing
- `WorkerCostsTestPayment` deducts correctly
- Built-in 25§ helper wage deductions are suppressed when a helper is active
- Pause menu shows active worker count, next payment timer and farm balance
- `WorkerCostsDiagnostic` reports all OK in log.txt