### PR TITLE
v1.0.9.3 — Fix wage settings callbacks, rapid cycling, help text, and enable toggle

### DIFF
--- a/modDesc.xml
+++ b/modDesc.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" standalone="no" ?>
 <modDesc descVersion="92">
     <author>TisonK</author>
-    <version>1.0.9.2</version>
+    <version>1.0.9.3</version>
     <modName>FS25_WorkerCostsMod</modName>
     <title>
         <en>Realistic Worker Costs</en>

--- a/modDesc.xml
+++ b/modDesc.xml
@@ -1222,6 +1222,141 @@ Fratrækkes hvert 5. realtidsminut, uafhængigt af spillets hastighed. Satsforh�
 
 Brug Nulstil for at gendanne alle indstillinger til standardværdierne.</da>
         </text>
+        <text name="wc_help_body_ha">
+            <en>COST MODE
+Per Hectare — workers are billed per hectare of field worked during each payment interval.
+
+WAGE LEVEL (per hectare)
+Low    = $15 per hectare worked
+Medium = $25 per hectare worked
+High   = $40 per hectare worked
+
+PAYMENTS
+Deducted every 5 real-time minutes based on area worked. Workers not currently active have no charge for that interval.
+
+Use Reset to restore all settings to their defaults.</en>
+
+            <de>[EN] COST MODE
+Per Hectare — workers are billed per hectare of field worked during each payment interval.
+
+WAGE LEVEL (per hectare)
+Low    = $15 per hectare worked
+Medium = $25 per hectare worked
+High   = $40 per hectare worked
+
+PAYMENTS
+Deducted every 5 real-time minutes based on area worked. Workers not currently active have no charge for that interval.
+
+Use Reset to restore all settings to their defaults.</de>
+            <fr>[EN] COST MODE
+Per Hectare — workers are billed per hectare of field worked during each payment interval.
+
+WAGE LEVEL (per hectare)
+Low    = $15 per hectare worked
+Medium = $25 per hectare worked
+High   = $40 per hectare worked
+
+PAYMENTS
+Deducted every 5 real-time minutes based on area worked. Workers not currently active have no charge for that interval.
+
+Use Reset to restore all settings to their defaults.</fr>
+            <pl>[EN] COST MODE
+Per Hectare — workers are billed per hectare of field worked during each payment interval.
+
+WAGE LEVEL (per hectare)
+Low    = $15 per hectare worked
+Medium = $25 per hectare worked
+High   = $40 per hectare worked
+
+PAYMENTS
+Deducted every 5 real-time minutes based on area worked. Workers not currently active have no charge for that interval.
+
+Use Reset to restore all settings to their defaults.</pl>
+            <es>[EN] COST MODE
+Per Hectare — workers are billed per hectare of field worked during each payment interval.
+
+WAGE LEVEL (per hectare)
+Low    = $15 per hectare worked
+Medium = $25 per hectare worked
+High   = $40 per hectare worked
+
+PAYMENTS
+Deducted every 5 real-time minutes based on area worked. Workers not currently active have no charge for that interval.
+
+Use Reset to restore all settings to their defaults.</es>
+            <it>[EN] COST MODE
+Per Hectare — workers are billed per hectare of field worked during each payment interval.
+
+WAGE LEVEL (per hectare)
+Low    = $15 per hectare worked
+Medium = $25 per hectare worked
+High   = $40 per hectare worked
+
+PAYMENTS
+Deducted every 5 real-time minutes based on area worked. Workers not currently active have no charge for that interval.
+
+Use Reset to restore all settings to their defaults.</it>
+            <cz>[EN] COST MODE
+Per Hectare — workers are billed per hectare of field worked during each payment interval.
+
+WAGE LEVEL (per hectare)
+Low    = $15 per hectare worked
+Medium = $25 per hectare worked
+High   = $40 per hectare worked
+
+PAYMENTS
+Deducted every 5 real-time minutes based on area worked. Workers not currently active have no charge for that interval.
+
+Use Reset to restore all settings to their defaults.</cz>
+            <br>[EN] COST MODE
+Per Hectare — workers are billed per hectare of field worked during each payment interval.
+
+WAGE LEVEL (per hectare)
+Low    = $15 per hectare worked
+Medium = $25 per hectare worked
+High   = $40 per hectare worked
+
+PAYMENTS
+Deducted every 5 real-time minutes based on area worked. Workers not currently active have no charge for that interval.
+
+Use Reset to restore all settings to their defaults.</br>
+            <uk>[EN] COST MODE
+Per Hectare — workers are billed per hectare of field worked during each payment interval.
+
+WAGE LEVEL (per hectare)
+Low    = $15 per hectare worked
+Medium = $25 per hectare worked
+High   = $40 per hectare worked
+
+PAYMENTS
+Deducted every 5 real-time minutes based on area worked. Workers not currently active have no charge for that interval.
+
+Use Reset to restore all settings to their defaults.</uk>
+            <ru>[EN] COST MODE
+Per Hectare — workers are billed per hectare of field worked during each payment interval.
+
+WAGE LEVEL (per hectare)
+Low    = $15 per hectare worked
+Medium = $25 per hectare worked
+High   = $40 per hectare worked
+
+PAYMENTS
+Deducted every 5 real-time minutes based on area worked. Workers not currently active have no charge for that interval.
+
+Use Reset to restore all settings to their defaults.</ru>
+            <da>OMKOSTNINGSTILSTAND
+Pr. hektar — medarbejdere opkræves pr. hektar bearbejdet mark i hvert betalingsinterval.
+
+LØNNIVEAU (pr. hektar)
+Lav = $15 pr. hektar bearbejdet
+Mellem = $25 pr. hektar bearbejdet
+Høj = $40 pr. hektar bearbejdet
+
+BETALINGER
+Fratrækkes hvert 5. realtidsminut baseret på bearbejdet areal. Medarbejdere, der ikke er aktive, opkræves ikke for det pågældende interval.
+
+Brug Nulstil for at gendanne alle indstillinger til standardværdierne.</da>
+        </text>
     </l10n>
 
 </modDesc>

--- a/modDesc.xml
+++ b/modDesc.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" standalone="no" ?>
 <modDesc descVersion="92">
     <author>TisonK</author>
-    <version>1.0.9.1</version>
+    <version>1.0.9.2</version>
     <modName>FS25_WorkerCostsMod</modName>
     <title>
         <en>Realistic Worker Costs</en>

--- a/src/gui/WCWageSettingsFrame.lua
+++ b/src/gui/WCWageSettingsFrame.lua
@@ -11,8 +11,9 @@ local WCWageSettingsFrame_mt = Class(WCWageSettingsFrame, TabbedMenuFrameElement
 
 function WCWageSettingsFrame.new()
     local self = WCWageSettingsFrame:superClass().new(nil, WCWageSettingsFrame_mt)
-    self.name      = "WCWageSettingsFrame"
-    self.className = "WCWageSettingsFrame"
+    self.name       = "WCWageSettingsFrame"
+    self.className  = "WCWageSettingsFrame"
+    self._refreshing = false
     return self
 end
 
@@ -25,65 +26,68 @@ function WCWageSettingsFrame:initialize()
     -- nothing extra needed at init time
 end
 
--- Wire up all the option widgets → settings
+-- Wire up all the option widgets → settings.
+-- Reads current widget state via getState() to avoid the FS25 target-as-first-arg
+-- issue where raiseCallback passes (self.target, state) to closures.
 function WCWageSettingsFrame:bindCallbacks()
-    -- Mod Enabled toggle
     if self.optEnabled then
-        self.optEnabled.onClickCallback = function(state)
+        self.optEnabled.onClickCallback = function(...)
+            if self._refreshing then return end
             if g_WorkerManager and g_WorkerManager.settings then
-                g_WorkerManager.settings.enabled = (state == 2)
+                g_WorkerManager.settings.enabled = (self.optEnabled:getState() == 2)
                 g_WorkerManager.settings:save()
             end
         end
     end
 
-    -- Cost Mode selector
     if self.optCostMode then
-        self.optCostMode.onClickCallback = function(state)
+        self.optCostMode.onClickCallback = function(...)
+            if self._refreshing then return end
             if g_WorkerManager and g_WorkerManager.settings then
-                g_WorkerManager.settings:setCostMode(state)
+                g_WorkerManager.settings:setCostMode(self.optCostMode:getState())
                 g_WorkerManager.settings:save()
                 self:refreshRatePreview()
+                self:refreshHelpText()
             end
         end
     end
 
-    -- Wage Level selector
     if self.optWageLevel then
-        self.optWageLevel.onClickCallback = function(state)
+        self.optWageLevel.onClickCallback = function(...)
+            if self._refreshing then return end
             if g_WorkerManager and g_WorkerManager.settings then
-                g_WorkerManager.settings:setWageLevel(state)
+                g_WorkerManager.settings:setWageLevel(self.optWageLevel:getState())
                 g_WorkerManager.settings:save()
                 self:refreshRatePreview()
             end
         end
     end
 
-    -- Notifications toggle
     if self.optNotifications then
-        self.optNotifications.onClickCallback = function(state)
+        self.optNotifications.onClickCallback = function(...)
+            if self._refreshing then return end
             if g_WorkerManager and g_WorkerManager.settings then
-                g_WorkerManager.settings.showNotifications = (state == 2)
+                g_WorkerManager.settings.showNotifications = (self.optNotifications:getState() == 2)
                 g_WorkerManager.settings:save()
             end
         end
     end
 
-    -- Debug mode toggle
     if self.optDebugMode then
-        self.optDebugMode.onClickCallback = function(state)
+        self.optDebugMode.onClickCallback = function(...)
+            if self._refreshing then return end
             if g_WorkerManager and g_WorkerManager.settings then
-                g_WorkerManager.settings.debugMode = (state == 2)
+                g_WorkerManager.settings.debugMode = (self.optDebugMode:getState() == 2)
                 g_WorkerManager.settings:save()
             end
         end
     end
 
-    -- Monthly salary dialog toggle
     if self.optMonthlySalary then
-        self.optMonthlySalary.onClickCallback = function(state)
+        self.optMonthlySalary.onClickCallback = function(...)
+            if self._refreshing then return end
             if g_WorkerManager and g_WorkerManager.settings then
-                g_WorkerManager.settings.monthlySalaryEnabled = (state == 2)
+                g_WorkerManager.settings.monthlySalaryEnabled = (self.optMonthlySalary:getState() == 2)
                 g_WorkerManager.settings:save()
             end
         end
@@ -99,11 +103,14 @@ function WCWageSettingsFrame:onFrameClose()
     WCWageSettingsFrame:superClass().onFrameClose(self)
 end
 
--- Sync all widgets to current settings values
+-- Sync all widgets to current settings values.
+-- The _refreshing guard prevents any incidental callback fires during setState.
 function WCWageSettingsFrame:refresh()
     if g_WorkerManager == nil then return end
     local settings = g_WorkerManager.settings
     if settings == nil then return end
+
+    self._refreshing = true
 
     if self.optEnabled and self.optEnabled.setState then
         self.optEnabled:setState(settings.enabled and 2 or 1)
@@ -142,12 +149,14 @@ function WCWageSettingsFrame:refresh()
         self.optDebugMode:setState(settings.debugMode and 2 or 1)
     end
 
-    -- Monthly salary dialog toggle (widget is optional — XML may not include it yet)
     if self.optMonthlySalary and self.optMonthlySalary.setState then
         self.optMonthlySalary:setState(settings.monthlySalaryEnabled and 2 or 1)
     end
 
+    self._refreshing = false
+
     self:refreshRatePreview()
+    self:refreshHelpText()
 end
 
 -- Update the live "effective rate" preview text
@@ -174,6 +183,20 @@ function WCWageSettingsFrame:refreshRatePreview()
         local ms  = g_WorkerManager.workerSystem.paymentInterval
         local min = math.floor(ms / 60000)
         self.txtPayInterval:setText(string.format("%d min", min))
+    end
+end
+
+-- Update the Cost Structure help body to reflect the active cost mode
+function WCWageSettingsFrame:refreshHelpText()
+    if self.txtHelpBody == nil then return end
+    if g_WorkerManager == nil then return end
+    local settings = g_WorkerManager.settings
+    if settings == nil then return end
+
+    if settings.costMode == Settings.COST_MODE_HOURLY then
+        self.txtHelpBody:setText(g_i18n:getText("wc_help_body"))
+    else
+        self.txtHelpBody:setText(g_i18n:getText("wc_help_body_ha"))
     end
 end
 

--- a/xml/gui/WCWageSettingsFrame.xml
+++ b/xml/gui/WCWageSettingsFrame.xml
@@ -35,19 +35,16 @@
                     <Text profile="WC_SectionTitle" position="10px -210px" text="$l10n_wc_section_cost_mode"/>
                     <ThreePartBitmap profile="fs25_lineSeparatorTop" position="5px -234px" width="520px"/>
 
-                    <BoxLayout profile="WC_RowBoxH" position="5px -256px" width="530px">
-                        <Text profile="WC_RowLabel" text="$l10n_wc_costmode_short" width="150px"/>
-                        <MultiTextOption profile="WC_FilterSwitcher" id="optCostMode" size="370px 32px"/>
-                    </BoxLayout>
+                    <!-- Absolute layout avoids BoxLayout input forwarding that caused rapid cycling (#41) -->
+                    <Text profile="WC_RowLabel" position="5px -263px" text="$l10n_wc_costmode_short" width="150px"/>
+                    <MultiTextOption profile="WC_FilterSwitcher" id="optCostMode" position="165px -256px" size="370px 32px"/>
 
                     <!-- WAGE LEVEL -->
                     <Text profile="WC_SectionTitle" position="10px -302px" text="$l10n_wc_section_wage_level"/>
                     <ThreePartBitmap profile="fs25_lineSeparatorTop" position="5px -326px" width="520px"/>
 
-                    <BoxLayout profile="WC_RowBoxH" position="5px -348px" width="530px">
-                        <Text profile="WC_RowLabel" text="$l10n_wc_difficulty_short" width="150px"/>
-                        <MultiTextOption profile="WC_FilterSwitcher" id="optWageLevel" size="370px 32px"/>
-                    </BoxLayout>
+                    <Text profile="WC_RowLabel" position="5px -355px" text="$l10n_wc_difficulty_short" width="150px"/>
+                    <MultiTextOption profile="WC_FilterSwitcher" id="optWageLevel" position="165px -348px" size="370px 32px"/>
 
                     <!-- Reset button (3-layer: Bg + Hit + Text) -->
                     <Bitmap profile="WC_BtnBgRed" id="btnResetBg" position="10px -422px" size="240px 40px"/>
@@ -82,7 +79,7 @@
 
                 <Text profile="WC_SectionTitle" position="0px -234px" text="$l10n_wc_help_title"/>
                 <ThreePartBitmap profile="fs25_lineSeparatorTop" position="0px -258px" width="400px"/>
-                <Text profile="WC_BodyText" position="0px -278px" size="400px 260px" text="$l10n_wc_help_body"/>
+                <Text profile="WC_BodyText" id="txtHelpBody" position="0px -278px" size="400px 260px" text="$l10n_wc_help_body"/>
 
             </GuiElement>
 


### PR DESCRIPTION
## Summary

- **#41** — Wage Level rapid infinite cycling: replaced `BoxLayout+MultiTextOption` rows with absolute-positioned elements; BoxLayout was intercepting mouse-release events, trapping the continuous-scroll flag
- **#43/#44** — Enable toggle and Cost Mode/Wage Level resetting on tab switch: FS25's `raiseCallback` passes the parent frame as first arg to closures; callbacks now read widget state via `getState()` instead of relying on the injected arg
- **#42** — Cost Structure help text now updates dynamically when switching between Hourly and Per Hectare modes; added `wc_help_body_ha` localisation key
- Added `_refreshing` guard in `refresh()` as defensive protection against any incidental callback fires during `setState`

## Test plan

- [ ] Toggle Enable Mod off → on → switch to Dashboard → return to Wage Settings — should show On
- [ ] Change Cost Mode to Per Hectare → switch tabs → return — should stay Per Hectare
- [ ] Change Wage Level to High → switch tabs → return — should stay High
- [ ] Press left/right on Wage Level — should cycle once per press with no runaway looping
- [ ] Switch Cost Mode to Per Hectare — Cost Structure panel should show per-hectare wage table
- [ ] Switch back to Hourly — Cost Structure panel should revert to hourly text
- [ ] Reset button should restore all widgets to defaults