### PR TITLE
Pro-Staff multiplayer + command API (2.1.0.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,6 +234,12 @@ Search for `[Worker Costs]` — all mod activity (when Debug Mode is on) and any
 
 ## Changelog
 
+### v2.1.0.0 — Pro-Staff Goes Multiplayer
+- New: **full multiplayer** — the roster is host-authoritative and syncs to every client; clients can hire, fire, and assign and the result broadcasts back to everyone
+- New: **recruitment pool** — a rotating set of candidates with their own level and one-off **signing cost**; hire a specific candidate or reroll the pool
+- New: **cross-mod command + financial API** — `hireWorker` / `fireWorker` / `assignWorker` plus an enriched roster snapshot (per-worker effective rate, severance, and Pro-Staff cost impact) for the Farm Tablet **Personnel** app
+- Change: the **Pro-Staff Panel** (ALT+H) now routes through the same command pipeline, so a host action also syncs to clients and hiring applies the signing cost everywhere
+
 ### v2.0.0.0 — Pro-Staff
 - New: **Pro-Staff roster** — the mod now keeps a real list of hired workers that survives save/reload, instead of nameless one-off helpers
 - New: workers gain **XP from hours worked** and rank up Novice → Experienced → Master (40h / 160h), with a promotion notice

--- a/modDesc.xml
+++ b/modDesc.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" standalone="no" ?>
 <modDesc descVersion="92">
     <author>TisonK</author>
-    <version>2.0.0.0</version>
+    <version>2.1.0.0</version>
     <modName>FS25_WorkerCostsMod</modName>
     <title>
         <en>Realistic Worker Costs</en>

--- a/src/WCNetworkEvents.lua
+++ b/src/WCNetworkEvents.lua
@@ -1,0 +1,305 @@
+-- =========================================================
+-- FS25 Realistic Worker Costs Mod — Network Events
+-- =========================================================
+-- Pro-Staff Phase 5 multiplayer layer. The roster is server-authoritative; the
+-- host owns it, persists it, and is the only peer that mutates it. Clients see a
+-- mirror via WCRosterSyncEvent and request management actions via
+-- WCWorkerCommandEvent. Flow mirrors SoilFertilizer's proven event design:
+--   client requests/commands -> server validates & applies -> server broadcasts.
+-- =========================================================
+-- Author: TisonK
+-- =========================================================
+-- COPYRIGHT NOTICE:
+-- All rights reserved. Unauthorized redistribution, copying,
+-- or claiming this code as your own is strictly prohibited.
+-- Original author: TisonK
+-- =========================================================
+
+-- Command action codes (kept tiny — sent as a UInt8 on the wire).
+WCCommand = {
+    HIRE         = 1,
+    FIRE         = 2,
+    ASSIGN       = 3,
+    UNASSIGN     = 4,
+    REFRESH_POOL = 5,
+}
+
+-- ---------------------------------------------------------------------------
+-- Shared snapshot serialization. The roster snapshot (built server-side by
+-- WorkerManager:getServerSnapshot) IS the wire format: the server computes every
+-- derived/financial value once and clients render exactly what they receive, so
+-- clients never need the settings or wage pipeline locally.
+-- ---------------------------------------------------------------------------
+local function writeSnapshot(streamId, snap)
+    snap = snap or {}
+    local levels   = snap.levels   or { novice = 0, experienced = 0, master = 0 }
+    local finance  = snap.finance  or {}
+    local workers  = snap.workers  or {}
+    local recruits = snap.recruits or {}
+
+    streamWriteInt32(streamId, snap.count   or 0)
+    streamWriteInt32(streamId, snap.working or 0)
+    streamWriteInt32(streamId, snap.pinned  or 0)
+    streamWriteInt32(streamId, levels.novice or 0)
+    streamWriteInt32(streamId, levels.experienced or 0)
+    streamWriteInt32(streamId, levels.master or 0)
+
+    -- Finance block
+    streamWriteFloat32(streamId, finance.baseRate or 0)
+    streamWriteBool(streamId,    finance.isHourly == true)
+    streamWriteString(streamId,  finance.costModeName or "")
+    streamWriteString(streamId,  finance.wageLevelName or "")
+    streamWriteInt32(streamId,   finance.monthAccrued or 0)
+    streamWriteInt32(streamId,   finance.estIntervalCost or 0)
+    streamWriteFloat32(streamId, finance.proStaffDelta or 0)
+
+    -- Workers
+    streamWriteInt32(streamId, #workers)
+    for _, w in ipairs(workers) do
+        streamWriteInt32(streamId,   w.uuid or 0)
+        streamWriteString(streamId,  w.name or "Worker")
+        streamWriteUInt8(streamId,   w.level or 1)
+        streamWriteFloat32(streamId, w.totalHours or 0)
+        streamWriteInt32(streamId,   w.totalJobs or 0)
+        streamWriteFloat32(streamId, w.fatigue or 0)
+        streamWriteBool(streamId,    w.working == true)
+        streamWriteBool(streamId,    w.pinned == true)
+        streamWriteFloat32(streamId, w.baseRate or 0)
+        streamWriteFloat32(streamId, w.effRate or 0)
+        streamWriteInt32(streamId,   w.severance or 0)
+    end
+
+    -- Recruit pool
+    streamWriteInt32(streamId, #recruits)
+    for _, r in ipairs(recruits) do
+        streamWriteUInt8(streamId,  r.slot or 1)
+        streamWriteString(streamId, r.name or "Recruit")
+        streamWriteUInt8(streamId,  r.level or 1)
+        streamWriteInt32(streamId,  r.hireCost or 0)
+    end
+end
+
+local function readSnapshot(streamId)
+    local snap = {
+        authoritative = true,   -- a received snapshot is, by definition, server truth
+        levels  = {},
+        finance = {},
+        workers = {},
+        recruits = {},
+    }
+
+    snap.count   = streamReadInt32(streamId)
+    snap.working = streamReadInt32(streamId)
+    snap.pinned  = streamReadInt32(streamId)
+    snap.levels.novice      = streamReadInt32(streamId)
+    snap.levels.experienced = streamReadInt32(streamId)
+    snap.levels.master      = streamReadInt32(streamId)
+
+    snap.finance.baseRate        = streamReadFloat32(streamId)
+    snap.finance.isHourly        = streamReadBool(streamId)
+    snap.finance.costModeName    = streamReadString(streamId)
+    snap.finance.wageLevelName   = streamReadString(streamId)
+    snap.finance.monthAccrued    = streamReadInt32(streamId)
+    snap.finance.estIntervalCost = streamReadInt32(streamId)
+    snap.finance.proStaffDelta   = streamReadFloat32(streamId)
+
+    local workerCount = streamReadInt32(streamId)
+    for _ = 1, workerCount do
+        local w = {}
+        w.uuid       = streamReadInt32(streamId)
+        w.name       = streamReadString(streamId)
+        w.level      = streamReadUInt8(streamId)
+        w.totalHours = streamReadFloat32(streamId)
+        w.totalJobs  = streamReadInt32(streamId)
+        w.fatigue    = streamReadFloat32(streamId)
+        w.working    = streamReadBool(streamId)
+        w.pinned     = streamReadBool(streamId)
+        w.baseRate   = streamReadFloat32(streamId)
+        w.effRate    = streamReadFloat32(streamId)
+        w.severance  = streamReadInt32(streamId)
+        -- Derive the display-only fields the server didn't ship.
+        w.levelName     = WorkerRoster.levelName(w.level)
+        w.proStaffDelta = (w.effRate or 0) - (w.baseRate or 0)
+        local status = w.working and "working" or "idle"
+        if w.pinned then status = status .. ", pinned" end
+        w.status = status
+        snap.workers[#snap.workers + 1] = w
+    end
+
+    local recruitCount = streamReadInt32(streamId)
+    for _ = 1, recruitCount do
+        local r = {}
+        r.slot     = streamReadUInt8(streamId)
+        r.name     = streamReadString(streamId)
+        r.level    = streamReadUInt8(streamId)
+        r.hireCost = streamReadInt32(streamId)
+        r.levelName = WorkerRoster.levelName(r.level)
+        snap.recruits[#snap.recruits + 1] = r
+    end
+
+    return snap
+end
+
+-- ========================================
+-- WORKER COMMAND EVENT (Client -> Server)
+-- ========================================
+-- A single command channel for every roster mutation. The server applies it and
+-- then broadcasts a fresh WCRosterSyncEvent so all peers converge.
+WCWorkerCommandEvent = {}
+WCWorkerCommandEvent_mt = Class(WCWorkerCommandEvent, Event)
+
+InitEventClass(WCWorkerCommandEvent, "WCWorkerCommandEvent")
+
+function WCWorkerCommandEvent.emptyNew()
+    return Event.new(WCWorkerCommandEvent_mt)
+end
+
+function WCWorkerCommandEvent.new(action, uuid, slot, vehicleUniqueId, farmId)
+    local self = WCWorkerCommandEvent.emptyNew()
+    self.action          = action or 0
+    self.uuid            = uuid or 0
+    self.slot            = slot or 1
+    self.vehicleUniqueId = vehicleUniqueId or ""
+    self.farmId          = farmId or 0
+    return self
+end
+
+function WCWorkerCommandEvent:readStream(streamId, connection)
+    self.action          = streamReadUInt8(streamId)
+    self.uuid            = streamReadInt32(streamId)
+    self.slot            = streamReadUInt8(streamId)
+    self.vehicleUniqueId = streamReadString(streamId)
+    self.farmId          = streamReadInt32(streamId)
+    self:run(connection)
+end
+
+function WCWorkerCommandEvent:writeStream(streamId, connection)
+    streamWriteUInt8(streamId,  self.action)
+    streamWriteInt32(streamId,  self.uuid)
+    streamWriteUInt8(streamId,  self.slot)
+    streamWriteString(streamId, self.vehicleUniqueId)
+    streamWriteInt32(streamId,  self.farmId)
+end
+
+function WCWorkerCommandEvent:run(connection)
+    -- SERVER ONLY: validate the originating farm, then apply + broadcast.
+    if g_server == nil then return end
+
+    local wm = g_currentMission and g_currentMission.workerCostsManager
+    if not wm then return end
+
+    -- Reject a spoofed/absent farm id for the money-spending actions. The client
+    -- sends its own getFarmId(); a real farm must exist for hire/fire to charge.
+    if (self.action == WCCommand.HIRE or self.action == WCCommand.FIRE) then
+        if not self.farmId or self.farmId == 0 then
+            Logging.warning("[Worker Costs] Rejected command (action=%d) — invalid farmId", self.action)
+            return
+        end
+    end
+
+    wm:_applyCommandFromNetwork(self.action, self.uuid, self.slot, self.vehicleUniqueId, self.farmId)
+end
+
+-- ========================================
+-- ROSTER SYNC EVENT (Server -> Client[s])
+-- ========================================
+-- Carries the full enriched snapshot. Sent to one connection on join request, and
+-- broadcast to all after every mutation. Pure clients cache it; the host ignores
+-- its own broadcast (it computes the snapshot live).
+WCRosterSyncEvent = {}
+WCRosterSyncEvent_mt = Class(WCRosterSyncEvent, Event)
+
+InitEventClass(WCRosterSyncEvent, "WCRosterSyncEvent")
+
+function WCRosterSyncEvent.emptyNew()
+    return Event.new(WCRosterSyncEvent_mt)
+end
+
+function WCRosterSyncEvent.new(snapshot)
+    local self = WCRosterSyncEvent.emptyNew()
+    self.snapshot = snapshot or {}
+    return self
+end
+
+function WCRosterSyncEvent:readStream(streamId, connection)
+    self.snapshot = readSnapshot(streamId)
+    self:run(connection)
+end
+
+function WCRosterSyncEvent:writeStream(streamId, connection)
+    writeSnapshot(streamId, self.snapshot)
+end
+
+function WCRosterSyncEvent:run(connection)
+    -- CLIENT ONLY. On a listen-server host g_server is set; it owns the live roster
+    -- and must not overwrite it with a mirror, so bail when we are the server.
+    if g_client == nil or g_server ~= nil then return end
+
+    local wm = g_currentMission and g_currentMission.workerCostsManager
+    if wm then
+        wm:applyClientSnapshot(self.snapshot)
+    end
+end
+
+-- ========================================
+-- REQUEST ROSTER SYNC (Client -> Server)
+-- ========================================
+WCRequestRosterSyncEvent = {}
+WCRequestRosterSyncEvent_mt = Class(WCRequestRosterSyncEvent, Event)
+
+InitEventClass(WCRequestRosterSyncEvent, "WCRequestRosterSyncEvent")
+
+function WCRequestRosterSyncEvent.emptyNew()
+    return Event.new(WCRequestRosterSyncEvent_mt)
+end
+
+function WCRequestRosterSyncEvent.new()
+    return WCRequestRosterSyncEvent.emptyNew()
+end
+
+function WCRequestRosterSyncEvent:readStream(streamId, connection)
+    self:run(connection)
+end
+
+function WCRequestRosterSyncEvent:writeStream(streamId, connection)
+    -- No payload.
+end
+
+function WCRequestRosterSyncEvent:run(connection)
+    -- SERVER ONLY: reply to the requesting connection with the current snapshot.
+    if g_server == nil or not connection then return end
+    local wm = g_currentMission and g_currentMission.workerCostsManager
+    if wm then
+        connection:sendEvent(WCRosterSyncEvent.new(wm:getServerSnapshot()))
+    end
+end
+
+-- ========================================
+-- HELPERS — the single entry points the rest of the mod calls
+-- ========================================
+
+--- Issue a roster command. Routes to the server on a client, applies directly on
+--- the server/SP. Every caller (tablet, roster panel) goes through here so the
+--- SP and MP paths can never drift.
+function WCNetwork_SendCommand(action, uuid, slot, vehicleUniqueId, farmId)
+    if g_client ~= nil and g_server == nil then
+        -- Pure client: ask the server.
+        g_client:getServerConnection():sendEvent(
+            WCWorkerCommandEvent.new(action, uuid, slot, vehicleUniqueId, farmId))
+    else
+        -- Server / single-player: apply immediately.
+        local wm = g_currentMission and g_currentMission.workerCostsManager
+        if wm then
+            wm:_applyCommandFromNetwork(action, uuid, slot, vehicleUniqueId, farmId)
+        end
+    end
+end
+
+--- Pure clients call this to pull the roster from the host (on join + retries).
+function WCNetwork_RequestRosterSync()
+    if g_client ~= nil and g_server == nil then
+        g_client:getServerConnection():sendEvent(WCRequestRosterSyncEvent.new())
+    end
+end
+
+Logging.info("[Worker Costs] Network events loaded (Pro-Staff MP layer)")

--- a/src/WorkerManager.lua
+++ b/src/WorkerManager.lua
@@ -27,6 +27,16 @@
 WorkerManager = {}
 local WorkerManager_mt = Class(WorkerManager)
 
+-- Pro-Staff Phase 5: recruitment pool. The host keeps a small rotating set of
+-- candidates the player can hire from the Farm Tablet Personnel app. Candidate
+-- names come from this pool (no text-input field on a controller-friendly tablet).
+WorkerManager.RECRUIT_POOL_SIZE = 4
+local RECRUIT_NAME_POOL = {
+    "Alex", "Sam", "Jordan", "Casey", "Riley", "Morgan", "Taylor", "Jamie",
+    "Drew", "Quinn", "Avery", "Parker", "Reese", "Skyler", "Hayden", "Rowan",
+    "Emerson", "Finley", "Sawyer", "Blake", "Charlie", "Dakota", "Elliot", "Frankie",
+}
+
 ---@param mission table  The FS25 Mission00 object
 ---@param modDirectory string
 ---@param modName string
@@ -134,6 +144,20 @@ function WorkerManager:update(dt)
     if self.rosterPanel then
         self.rosterPanel:update()
     end
+
+    -- Pro-Staff Phase 5: a pure MP client pulls the roster mirror from the host.
+    -- Retry a handful of times in case our first request beats the host's mod init
+    -- on join; stop as soon as the first snapshot lands.
+    if g_currentMission and not g_currentMission:getIsServer() then
+        if self.clientRosterSnapshot == nil and (self._syncRetries or 0) < 6 then
+            self._syncRetryTimer = (self._syncRetryTimer or 2500) + dt
+            if self._syncRetryTimer >= 2500 then
+                self._syncRetryTimer = 0
+                self._syncRetries = (self._syncRetries or 0) + 1
+                WCNetwork_RequestRosterSync()
+            end
+        end
+    end
 end
 
 -- Pro-Staff Phase 0: roster persistence entry points.
@@ -162,68 +186,287 @@ function WorkerManager:loadWorkerData()
     self.workerRoster:loadIfExists(missionInfo)
 end
 
--- Pro-Staff Phase 5: read-only roster snapshot — the cross-repo contract from
--- docs/PRO_STAFF_PLAN.md §5. Other mods (notably the Farm Tablet Pro-Staff app)
--- read the roster through this method instead of reaching into roster/worker
--- internals, so the storage layout stays free to change. Returns a fresh plain
--- table; does no I/O and is safe to call per-frame.
---
--- The roster is server-authoritative. On a multiplayer CLIENT it is not synced yet
--- (MP sync is the remaining Phase 5 sub-batch), so `authoritative` is false and the
--- worker list is empty — consumers should show a "host-managed" note rather than
--- presenting an empty roster as the truth.
-function WorkerManager:getRosterSnapshot()
-    local authoritative = (g_currentMission ~= nil
-        and g_currentMission.getIsServer ~= nil
-        and g_currentMission:getIsServer()) and true or false
+-- =========================================================
+-- Pro-Staff Phase 5: recruitment pool (server-authoritative)
+-- =========================================================
+
+-- Roll a single recruit. Level is weighted toward Novice; the occasional
+-- Experienced/Master recruit costs more to sign (computeHireCost scales by level).
+function WorkerManager:_generateRecruit()
+    local r = math.random()
+    local level
+    if r < 0.70 then
+        level = WorkerRoster.LEVEL_NOVICE
+    elseif r < 0.93 then
+        level = WorkerRoster.LEVEL_EXPERIENCED
+    else
+        level = WorkerRoster.LEVEL_MASTER
+    end
+
+    local name = RECRUIT_NAME_POOL[math.random(1, #RECRUIT_NAME_POOL)]
+    local hireCost = self.workerSystem and self.workerSystem:computeHireCost(level) or 0
+    return { name = name, level = level, hireCost = hireCost }
+end
+
+-- The current pool, generated lazily and refilled after each hire. Server/SP only;
+-- clients read the pool through the synced snapshot.
+function WorkerManager:getRecruitPool()
+    if not self.recruitPool then
+        self:refreshRecruitPool()
+    end
+    return self.recruitPool
+end
+
+function WorkerManager:refreshRecruitPool()
+    self.recruitPool = {}
+    for i = 1, WorkerManager.RECRUIT_POOL_SIZE do
+        self.recruitPool[i] = self:_generateRecruit()
+    end
+end
+
+-- =========================================================
+-- Pro-Staff Phase 5: roster snapshot — the cross-repo read contract
+-- =========================================================
+
+-- Build the live, enriched snapshot. Server/SP only — it reads roster, settings,
+-- and the wage pipeline. The snapshot doubles as the multiplayer wire format
+-- (WCRosterSyncEvent), so every derived value clients need is computed here once.
+function WorkerManager:getServerSnapshot()
+    local settings   = self.settings
+    local workerSys  = self.workerSystem
+    local baseRate   = (settings and settings.getWageRate and settings:getWageRate()) or 0
+    local isHourly   = (settings and settings.costMode == Settings.COST_MODE_HOURLY) and true or false
+
+    -- Aggregate "this month" accrued wages from the worker system.
+    local monthAccrued = 0
+    if workerSys and workerSys.monthlyCosts then
+        for _, amt in pairs(workerSys.monthlyCosts) do
+            monthAccrued = monthAccrued + (amt or 0)
+        end
+    end
 
     local snapshot = {
-        authoritative = authoritative,
+        authoritative = true,
         count   = 0,
         working = 0,   -- workers currently driving a vehicle on a live AI job
         pinned  = 0,   -- workers with a persistent vehicle assignment
         levels  = { novice = 0, experienced = 0, master = 0 },
         workers = {},
+        recruits = {},
+        finance = {
+            baseRate        = baseRate,
+            isHourly        = isHourly,
+            costModeName    = (settings and settings.getCostModeName and settings:getCostModeName()) or "",
+            wageLevelName   = (settings and settings.getWageLevelName and settings:getWageLevelName()) or "",
+            monthAccrued    = math.floor(monthAccrued),
+            estIntervalCost = (workerSys and workerSys.getEstimatedIntervalCost and workerSys:getEstimatedIntervalCost()) or 0,
+            proStaffDelta   = 0,   -- summed below
+        },
     }
 
-    if not self.workerRoster then
-        return snapshot
+    if self.workerRoster then
+        for _, w in ipairs(self.workerRoster:getAll()) do
+            local isWorking = w.assignedVehicleId ~= nil
+            local isPinned  = w.assignedVehicleUniqueId ~= nil
+            local status    = isWorking and "working" or "idle"
+            if isPinned then status = status .. ", pinned" end
+
+            snapshot.count = snapshot.count + 1
+            if isWorking then snapshot.working = snapshot.working + 1 end
+            if isPinned  then snapshot.pinned  = snapshot.pinned  + 1 end
+
+            local level = w.level or WorkerRoster.LEVEL_NOVICE
+            if level == WorkerRoster.LEVEL_MASTER then
+                snapshot.levels.master = snapshot.levels.master + 1
+            elseif level == WorkerRoster.LEVEL_EXPERIENCED then
+                snapshot.levels.experienced = snapshot.levels.experienced + 1
+            else
+                snapshot.levels.novice = snapshot.levels.novice + 1
+            end
+
+            -- Indicative per-worker rate: base * level-efficiency, then fatigue
+            -- surcharge (Master is immune). Situational night/weather/overtime
+            -- multipliers are deliberately excluded — this is the steady-state rate.
+            local fatigue     = w.fatigue or 0
+            local levelFactor = WorkerSystem.LEVEL_WAGE_FACTOR[level] or 1.0
+            local effRate     = baseRate * levelFactor
+            if level ~= WorkerRoster.LEVEL_MASTER and fatigue > 0 then
+                effRate = effRate * (1 + fatigue * WorkerSystem.FATIGUE_SURCHARGE)
+            end
+            snapshot.finance.proStaffDelta = snapshot.finance.proStaffDelta + (effRate - baseRate)
+
+            table.insert(snapshot.workers, {
+                uuid       = w.uuid,
+                name       = w.name or "Worker",
+                level      = level,
+                levelName  = WorkerRoster.levelName(level),
+                totalHours = w.totalHours or 0,
+                totalJobs  = w.totalJobs or 0,
+                fatigue    = fatigue,   -- 0..1
+                working    = isWorking,
+                pinned     = isPinned,
+                status     = status,
+                baseRate   = baseRate,
+                effRate    = effRate,
+                proStaffDelta = effRate - baseRate,
+                severance  = (workerSys and workerSys:computeSeverance(level)) or 0,
+            })
+        end
     end
 
-    for _, w in ipairs(self.workerRoster:getAll()) do
-        local isWorking = w.assignedVehicleId ~= nil
-        local isPinned  = w.assignedVehicleUniqueId ~= nil
-        local status    = isWorking and "working" or "idle"
-        if isPinned then status = status .. ", pinned" end
-
-        snapshot.count = snapshot.count + 1
-        if isWorking then snapshot.working = snapshot.working + 1 end
-        if isPinned  then snapshot.pinned  = snapshot.pinned  + 1 end
-
-        local level = w.level or WorkerRoster.LEVEL_NOVICE
-        if level == WorkerRoster.LEVEL_MASTER then
-            snapshot.levels.master = snapshot.levels.master + 1
-        elseif level == WorkerRoster.LEVEL_EXPERIENCED then
-            snapshot.levels.experienced = snapshot.levels.experienced + 1
-        else
-            snapshot.levels.novice = snapshot.levels.novice + 1
-        end
-
-        table.insert(snapshot.workers, {
-            uuid       = w.uuid,
-            name       = w.name or "Worker",
-            level      = level,
-            levelName  = WorkerRoster.levelName(level),
-            totalHours = w.totalHours or 0,
-            totalJobs  = w.totalJobs or 0,
-            fatigue    = w.fatigue or 0,   -- 0..1
-            working    = isWorking,
-            pinned     = isPinned,
-            status     = status,
+    -- Recruit pool (slot-indexed so the client can name the exact slot to hire).
+    for i, cand in ipairs(self:getRecruitPool()) do
+        table.insert(snapshot.recruits, {
+            slot      = i,
+            name      = cand.name,
+            level     = cand.level,
+            levelName = WorkerRoster.levelName(cand.level),
+            hireCost  = cand.hireCost,
         })
     end
 
     return snapshot
+end
+
+-- The public read contract. Server/SP computes live; a pure MP client returns the
+-- last snapshot synced from the host (or an empty, non-authoritative placeholder
+-- until the first sync arrives, so consumers can show a "host-managed" note).
+function WorkerManager:getRosterSnapshot()
+    local isServer = (g_currentMission ~= nil
+        and g_currentMission.getIsServer ~= nil
+        and g_currentMission:getIsServer()) and true or false
+
+    if isServer then
+        return self:getServerSnapshot()
+    end
+
+    return self.clientRosterSnapshot or {
+        authoritative = false,
+        count   = 0,
+        working = 0,
+        pinned  = 0,
+        levels  = { novice = 0, experienced = 0, master = 0 },
+        workers = {},
+        recruits = {},
+        finance = {},
+    }
+end
+
+-- Client stores the host's snapshot mirror (called from WCRosterSyncEvent).
+function WorkerManager:applyClientSnapshot(snapshot)
+    self.clientRosterSnapshot = snapshot
+end
+
+-- =========================================================
+-- Pro-Staff Phase 5: worker management command API
+-- =========================================================
+-- Public methods every UI calls. They route through WCNetwork_SendCommand so the
+-- SP path (apply now) and MP path (ask the host) share one code path. farmId
+-- defaults to the caller's own farm so the right account is charged in MP.
+
+local function localFarmId()
+    return (g_currentMission and g_currentMission:getFarmId()) or 0
+end
+
+function WorkerManager:hireWorker(slot, farmId)
+    WCNetwork_SendCommand(WCCommand.HIRE, 0, slot or 1, "", farmId or localFarmId())
+end
+
+function WorkerManager:fireWorker(uuid, farmId)
+    WCNetwork_SendCommand(WCCommand.FIRE, uuid or 0, 0, "", farmId or localFarmId())
+end
+
+function WorkerManager:assignWorker(uuid, vehicleUniqueId)
+    WCNetwork_SendCommand(WCCommand.ASSIGN, uuid or 0, 0, vehicleUniqueId or "", 0)
+end
+
+function WorkerManager:unassignWorker(uuid)
+    WCNetwork_SendCommand(WCCommand.UNASSIGN, uuid or 0, 0, "", 0)
+end
+
+function WorkerManager:refreshRecruits()
+    WCNetwork_SendCommand(WCCommand.REFRESH_POOL, 0, 0, "", 0)
+end
+
+-- Server-side executor. Invoked directly in SP, or from WCWorkerCommandEvent on the
+-- host. Applies one mutation, persists, then broadcasts the new snapshot to clients.
+function WorkerManager:_applyCommandFromNetwork(action, uuid, slot, vehicleUniqueId, farmId)
+    if not self.workerRoster then return end
+
+    if action == WCCommand.HIRE then
+        self:_doHire(slot, farmId)
+    elseif action == WCCommand.FIRE then
+        self:_doFire(uuid, farmId)
+    elseif action == WCCommand.ASSIGN then
+        self:_doAssign(uuid, vehicleUniqueId)
+    elseif action == WCCommand.UNASSIGN then
+        self:_doUnassign(uuid)
+    elseif action == WCCommand.REFRESH_POOL then
+        self:refreshRecruitPool()
+    else
+        return
+    end
+
+    self:saveWorkerData()
+    self:_broadcastRosterSync()
+end
+
+function WorkerManager:_doHire(slot, farmId)
+    local pool = self:getRecruitPool()
+    slot = slot or 1
+    local cand = pool[slot]
+    if not cand then
+        return
+    end
+
+    if self.workerSystem then
+        self.workerSystem:chargeHireCost(cand.name, cand.level, farmId)
+    end
+
+    local w = self.workerRoster:createWorker(cand.name)
+    -- Seed XP so the recruit's advertised level holds after recomputeLevel().
+    if cand.level == WorkerRoster.LEVEL_EXPERIENCED then
+        w.totalXP = WorkerRoster.XP_EXPERIENCED
+    elseif cand.level == WorkerRoster.LEVEL_MASTER then
+        w.totalXP = WorkerRoster.XP_MASTER
+    end
+    self.workerRoster:recomputeLevel(w)
+
+    -- Consume the slot and refill so the pool always offers a full set.
+    table.remove(pool, slot)
+    table.insert(pool, self:_generateRecruit())
+
+    Logging.info("[Worker Costs] Hired %s (level %d, id=%d)", cand.name, cand.level, w.uuid)
+end
+
+function WorkerManager:_doFire(uuid, farmId)
+    local w = self.workerRoster:getWorker(uuid)
+    if not w then
+        return
+    end
+    if self.workerSystem then
+        self.workerSystem:chargeSeverance(w.name or "Worker", w.level, farmId)
+    end
+    self.workerRoster:removeWorker(uuid)
+    Logging.info("[Worker Costs] Fired worker id=%d", uuid)
+end
+
+function WorkerManager:_doAssign(uuid, vehicleUniqueId)
+    if not vehicleUniqueId or vehicleUniqueId == "" then
+        return
+    end
+    self.workerRoster:assignVehiclePersistent(uuid, vehicleUniqueId)
+end
+
+function WorkerManager:_doUnassign(uuid)
+    self.workerRoster:unassignPersistent(uuid)
+end
+
+-- Push the fresh snapshot to all clients after a mutation (no-op in SP).
+function WorkerManager:_broadcastRosterSync()
+    if g_server ~= nil then
+        g_server:broadcastEvent(WCRosterSyncEvent.new(self:getServerSnapshot()))
+    end
 end
 
 -- Phase 5: register the rebindable WC_OPEN_ROSTER action (default ALT+H, shown in

--- a/src/WorkerSystem.lua
+++ b/src/WorkerSystem.lua
@@ -31,6 +31,10 @@ WorkerSystem.OVERTIME_MULT     = 1.50   -- premium once a vehicle passes the dai
 -- Phase 5 severance: one-off payout when firing. Senior workers cost more to let go.
 WorkerSystem.SEVERANCE_HOURS        = 16
 WorkerSystem.SEVERANCE_LEVEL_FACTOR = { [1] = 1.0, [2] = 1.5, [3] = 2.0 }
+-- Pro-Staff Phase 5: one-off signing cost when hiring a recruit. A more experienced
+-- recruit commands a bigger signing bonus. Expressed in "hours of base wage" so it
+-- scales with the configured wage level, exactly like severance.
+WorkerSystem.HIRE_COST_HOURS        = { [1] = 8, [2] = 24, [3] = 60 }
 
 ---@param settings Settings
 ---@param roster WorkerRoster|nil  Pro-Staff roster for level/fatigue (Phase 3)
@@ -391,13 +395,15 @@ function WorkerSystem:computeSeverance(level)
     return math.floor(rate * WorkerSystem.SEVERANCE_HOURS * factor)
 end
 
---- Charge severance to the player's farm. Returns the amount charged (0 if none).
-function WorkerSystem:chargeSeverance(workerName, level)
+--- Charge severance to a farm. Returns the amount charged (0 if none).
+-- farmId is optional — defaults to the local player's farm (SP/host). In multiplayer
+-- the command pipeline passes the requesting player's farm so the right account pays.
+function WorkerSystem:chargeSeverance(workerName, level, farmId)
     local amount = self:computeSeverance(level)
     if amount <= 0 then
         return 0
     end
-    local farmId = g_currentMission and g_currentMission:getFarmId()
+    farmId = farmId or (g_currentMission and g_currentMission:getFarmId())
     if not farmId or farmId == 0 then
         return 0
     end
@@ -409,6 +415,37 @@ function WorkerSystem:chargeSeverance(workerName, level)
     if ok and self.settings.showNotifications then
         local money = g_i18n and g_i18n:formatMoney(amount, 0, true, true) or ("$" .. amount)
         self:showNotification("Severance", string.format("%s dismissed - severance %s", workerName, money))
+    end
+    return ok and amount or 0
+end
+
+-- Pro-Staff Phase 5: signing cost for hiring a recruit of the given level.
+function WorkerSystem:computeHireCost(level)
+    local rate = self.settings:getWageRate()
+    local hours = WorkerSystem.HIRE_COST_HOURS[level] or WorkerSystem.HIRE_COST_HOURS[1]
+    return math.floor(rate * hours)
+end
+
+--- Charge a hiring/signing cost to a farm. Returns the amount charged (0 if none).
+-- Same farmId contract as chargeSeverance — defaults to the local farm, overridden
+-- by the MP command pipeline so the requesting player's account pays.
+function WorkerSystem:chargeHireCost(workerName, level, farmId)
+    local amount = self:computeHireCost(level)
+    if amount <= 0 then
+        return 0
+    end
+    farmId = farmId or (g_currentMission and g_currentMission:getFarmId())
+    if not farmId or farmId == 0 then
+        return 0
+    end
+    self._isProcessingPayment = true
+    local ok = pcall(function()
+        g_currentMission:addMoney(-amount, farmId, MoneyType.OTHER, false)
+    end)
+    self._isProcessingPayment = false
+    if ok and self.settings.showNotifications then
+        local money = g_i18n and g_i18n:formatMoney(amount, 0, true, true) or ("$" .. amount)
+        self:showNotification("New Hire", string.format("%s hired - signing cost %s", workerName, money))
     end
     return ok and amount or 0
 end

--- a/src/gui/WCRosterPanel.lua
+++ b/src/gui/WCRosterPanel.lua
@@ -352,26 +352,39 @@ function WCRosterPanel:handleClick(id, data)
         return
     end
 
-    -- Mutations are server/SP only for now (MP sync is a later sub-batch).
+    -- This panel renders from the local roster, which only the host holds, so it
+    -- stays server/SP only. MP clients manage workers from the Farm Tablet Personnel
+    -- app instead (it reads the synced snapshot). All mutations now route through the
+    -- WorkerManager command API so a host action also broadcasts to clients and the
+    -- recruit-pool / hire-cost rules apply everywhere (single source of truth).
     if not self:_isServer() then
-        self.infoMsg = "Only the host can manage workers (MP sync coming later)"
+        self.infoMsg = "Only the host can manage workers from this panel"
         return
     end
     if self.roster == nil then return end
 
+    local mgr = g_currentMission and g_currentMission.workerCostsManager
+
     if id == "hire" then
-        local name = NAME_POOL[math.random(1, #NAME_POOL)]
-        local w = self.roster:createWorker(name)
-        self.infoMsg = string.format("Hired %s (id=%d)", w.name, w.uuid)
+        if mgr then
+            local pool = mgr:getRecruitPool()
+            local cand = pool and pool[1]
+            mgr:hireWorker(1)
+            if cand then
+                local money = g_i18n and g_i18n:formatMoney(cand.hireCost or 0, 0, true, true) or ("$" .. (cand.hireCost or 0))
+                self.infoMsg = string.format("Hired %s  (signing %s)", cand.name, money)
+            else
+                self.infoMsg = "No recruits available"
+            end
+        end
 
     elseif id:sub(1, 5) == "fire_" and data then
-        local severance = 0
-        if self.workerSystem then
-            severance = self.workerSystem:chargeSeverance(data.name or "Worker", data.level)
+        if mgr then
+            local severance = (mgr.workerSystem and mgr.workerSystem:computeSeverance(data.level)) or 0
+            mgr:fireWorker(data.uuid)
+            local money = g_i18n and g_i18n:formatMoney(severance, 0, true, true) or ("$" .. severance)
+            self.infoMsg = string.format("Fired %s  (severance %s)", data.name or "Worker", money)
         end
-        self.roster:removeWorker(data.uuid)
-        local money = g_i18n and g_i18n:formatMoney(severance, 0, true, true) or ("$" .. severance)
-        self.infoMsg = string.format("Fired %s  (severance %s)", data.name or "Worker", money)
 
     elseif id:sub(1, 7) == "assign_" and data then
         local vehicle = self:_getCurrentVehicle()
@@ -384,12 +397,12 @@ function WCRosterPanel:handleClick(id, data)
             self.infoMsg = "That vehicle has no stable id yet - save once, then assign"
             return
         end
-        self.roster:assignVehiclePersistent(data.uuid, uniqueId)
+        if mgr then mgr:assignWorker(data.uuid, uniqueId) end
         local vname = (vehicle.getFullName and vehicle:getFullName()) or "vehicle"
         self.infoMsg = string.format("Pinned to %s", vname)
 
     elseif id:sub(1, 9) == "unassign_" and data then
-        self.roster:unassignPersistent(data.uuid)
+        if mgr then mgr:unassignWorker(data.uuid) end
         self.infoMsg = "Pin removed"
     end
 end

--- a/src/main.lua
+++ b/src/main.lua
@@ -19,7 +19,7 @@ local modName = g_currentModName
 --   [x] Phase 0 — source WorkerRoster; install roster save hook (FSCareerMissionInfo)
 --   [x] Phase 1 — source WorkerJobTracker (subscribes to AI_JOB_STARTED/STOPPED
 --                 in WorkerManager:onMissionLoaded)
---   [ ] Phase 5 — register network events for MP roster sync
+--   [x] Phase 5 — source WCNetworkEvents (MP roster sync + worker command events)
 -- =========================================================
 
 -- Load all source files in correct order
@@ -33,6 +33,7 @@ source(modDirectory .. "src/WorkerSystem.lua")
 source(modDirectory .. "src/WorkerJobTracker.lua")
 source(modDirectory .. "src/gui/WCRosterPanel.lua") -- created in WorkerManager.new, so load before it
 source(modDirectory .. "src/WorkerManager.lua")
+source(modDirectory .. "src/WCNetworkEvents.lua")   -- Pro-Staff Phase 5: MP roster sync + command events
 
 -- GUI: pause-menu tab + inner tabbed manager
 source(modDirectory .. "src/gui/WCDashboardFrame.lua")


### PR DESCRIPTION
Adds the multiplayer roster layer and a cross-mod command/financial API that powers the new Farm Tablet Personnel app.

## What's new
- Host-authoritative roster that syncs to all clients
- Client to host command pipeline for hire / fire / assign / unassign
- Recruitment pool with per-candidate level and signing cost
- Enriched roster snapshot (effective rate, severance, Pro-Staff cost impact) that also serves as the MP wire format
- Pro-Staff Panel (ALT+H) now routes through the same command API, so host actions broadcast to clients

Tested in singleplayer: hire/fire/assign and the tablet integration work, workers run their jobs normally.