### PR TITLE
v2.2.0.0 - Hiring Hall

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,6 +234,12 @@ Search for `[Worker Costs]` — all mod activity (when Debug Mode is on) and any
 
 ## Changelog
 
+### v2.2.0.0 — Hiring Hall
+- New: **daily hiring limit** — hire at most 5 workers from the Hiring Hall per in-game day; the counter resets each morning, survives reload, and you get a clear notice when you hit the cap (#69)
+- New: **Trusted employees** — star a worker in the Pro-Staff Panel to keep them pinned at the top of the list; the status is saved and shows for everyone in multiplayer (#67)
+- New: **earned mastery** — Master workers no longer turn up in the recruitment pool; Master is now reached only by working and gaining XP, and Experienced recruits unlock as your staff put in the hours (#68)
+- New: **job history** — every worker keeps a short resume of recent jobs (completed, dismissed, or failed, with hours and a cost estimate), recorded the moment a job ends (#66)
+
 ### v2.1.0.0 — Pro-Staff Goes Multiplayer
 - New: **full multiplayer** — the roster is host-authoritative and syncs to every client; clients can hire, fire, and assign and the result broadcasts back to everyone
 - New: **recruitment pool** — a rotating set of candidates with their own level and one-off **signing cost**; hire a specific candidate or reroll the pool

--- a/modDesc.xml
+++ b/modDesc.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" standalone="no" ?>
 <modDesc descVersion="92">
     <author>TisonK</author>
-    <version>2.1.0.0</version>
+    <version>2.2.0.0</version>
     <modName>FS25_WorkerCostsMod</modName>
     <title>
         <en>Realistic Worker Costs</en>

--- a/src/WCNetworkEvents.lua
+++ b/src/WCNetworkEvents.lua
@@ -22,6 +22,7 @@ WCCommand = {
     ASSIGN       = 3,
     UNASSIGN     = 4,
     REFRESH_POOL = 5,
+    SET_TRUSTED  = 6,   -- #67: toggle a worker's Trusted/favorite flag
 }
 
 -- ---------------------------------------------------------------------------
@@ -53,6 +54,12 @@ local function writeSnapshot(streamId, snap)
     streamWriteInt32(streamId,   finance.estIntervalCost or 0)
     streamWriteFloat32(streamId, finance.proStaffDelta or 0)
 
+    -- Hiring quota block (#69)
+    local hiring = snap.hiring or {}
+    streamWriteInt32(streamId, hiring.limit or 0)
+    streamWriteInt32(streamId, hiring.usedToday or 0)
+    streamWriteInt32(streamId, hiring.remaining or 0)
+
     -- Workers
     streamWriteInt32(streamId, #workers)
     for _, w in ipairs(workers) do
@@ -64,6 +71,7 @@ local function writeSnapshot(streamId, snap)
         streamWriteFloat32(streamId, w.fatigue or 0)
         streamWriteBool(streamId,    w.working == true)
         streamWriteBool(streamId,    w.pinned == true)
+        streamWriteBool(streamId,    w.trusted == true)   -- #67
         streamWriteFloat32(streamId, w.baseRate or 0)
         streamWriteFloat32(streamId, w.effRate or 0)
         streamWriteInt32(streamId,   w.severance or 0)
@@ -103,6 +111,13 @@ local function readSnapshot(streamId)
     snap.finance.estIntervalCost = streamReadInt32(streamId)
     snap.finance.proStaffDelta   = streamReadFloat32(streamId)
 
+    -- Hiring quota block (#69)
+    snap.hiring = {
+        limit     = streamReadInt32(streamId),
+        usedToday = streamReadInt32(streamId),
+        remaining = streamReadInt32(streamId),
+    }
+
     local workerCount = streamReadInt32(streamId)
     for _ = 1, workerCount do
         local w = {}
@@ -114,6 +129,7 @@ local function readSnapshot(streamId)
         w.fatigue    = streamReadFloat32(streamId)
         w.working    = streamReadBool(streamId)
         w.pinned     = streamReadBool(streamId)
+        w.trusted    = streamReadBool(streamId)   -- #67
         w.baseRate   = streamReadFloat32(streamId)
         w.effRate    = streamReadFloat32(streamId)
         w.severance  = streamReadInt32(streamId)

--- a/src/WorkerJobTracker.lua
+++ b/src/WorkerJobTracker.lua
@@ -228,6 +228,18 @@ function WorkerJobTracker:_notifyLevelUp(worker, newLevel)
     end
 end
 
+-- True when no live AI job is currently attributed to this worker. Authoritative
+-- task-occupancy check consumed by HireHallCore's availability broker (FR3 cond.3).
+-- O(active jobs) — the active set is tiny (one entry per in-flight helper).
+function WorkerJobTracker:isWorkerIdle(workerId)
+    for _, rec in pairs(self.activeJobs) do
+        if rec.workerUuid == workerId then
+            return false
+        end
+    end
+    return true
+end
+
 -- ---------------------------------------------------------------------------
 -- Resolution helpers
 -- ---------------------------------------------------------------------------

--- a/src/WorkerJobTracker.lua
+++ b/src/WorkerJobTracker.lua
@@ -61,6 +61,8 @@ function WorkerJobTracker.new(roster, settings)
     -- START and STOP handlers on the server, so this needs no job id lookup.
     self.activeJobs  = {}
     self.subscribed  = false
+    -- Monotonic per-session job sequence ("Task ID" for the FR5 history resume).
+    self.jobSeq      = 0
     return self
 end
 
@@ -136,11 +138,16 @@ function WorkerJobTracker:_onJobStarted(job, startFarmId)
     end
 
     local now = (g_currentMission and g_currentMission.time) or 0
+    self.jobSeq = self.jobSeq + 1
     self.activeJobs[job] = {
         workerUuid = worker.uuid,
         vehicleId  = tostring(vehicle),
         startTime  = now,
         name       = worker.name,
+        -- FR5 history: capture the rank at start so a mid-job promotion is visible
+        -- (StartRank vs EndRank), plus a stable per-session task id.
+        startLevel = worker.level or WorkerRoster.LEVEL_NOVICE,
+        seq        = self.jobSeq,
     }
     self:log("Job started: '%s' (uuid=%d) on %s", worker.name, worker.uuid, tostring(vehicle))
 end
@@ -181,6 +188,22 @@ function WorkerJobTracker:_onJobStopped(job, aiMessage)
 
     if newLevel then
         self:_notifyLevelUp(worker, newLevel)
+    end
+
+    -- FR5 (#66): hand the resolved job-end facts to the Internal Job Termination
+    -- Monitor via the core event bus. We do the resolving (worker, hours, ranks);
+    -- the monitor classifies the outcome and writes the history buffer. Emitting
+    -- here (the AI_JOB_STOPPED handler) keeps the monitor purely event-driven.
+    if HireHallCore ~= nil and HireHallCore.Events ~= nil then
+        HireHallCore.Events:onWorkerJobEnded({
+            workerUuid = worker.uuid,
+            seq        = rec.seq,
+            hours      = hours,
+            startLevel = rec.startLevel or worker.level,
+            endLevel   = worker.level,
+            fatigue    = worker.fatigue or 0,
+            aiMessage  = aiMessage,   -- transient; the monitor stores only a token
+        })
     end
 end
 

--- a/src/WorkerManager.lua
+++ b/src/WorkerManager.lua
@@ -63,6 +63,15 @@ function WorkerManager.new(mission, modDirectory, modName)
     -- pipeline and recovers idle workers' fatigue daily.
     self.workerSystem = WorkerSystem.new(self.settings, self.workerRoster)
 
+    -- HireHallCore framework (FR0-FR4): server-authoritative personnel lifecycle
+    -- layered on top of the existing roster. Read-only consumer of Pro-Staff data;
+    -- isolates its own state in worker.hireHallMeta and its own hireHallCore.xml.
+    -- The global IS the singleton; self.hireHall just aliases it for the coordinator.
+    if HireHallCore then
+        self.hireHall = HireHallCore:setup(self.workerRoster, self.settings,
+            self.workerSystem, self.jobTracker)
+    end
+
     -- Phase 5: clickable roster panel (custom-drawn overlay). Client-only — it
     -- renders. Opened via the WorkerCostsRoster console command.
     if mission:getIsClient() and WCRosterPanel then
@@ -120,6 +129,12 @@ function WorkerManager:onMissionLoaded()
         if self.jobTracker then
             self.jobTracker:initialize()
         end
+
+        -- HireHallCore: give each loaded worker a lifecycle meta block and apply
+        -- any persisted states. Host-only (the broker reads the real roster).
+        if self.hireHall then
+            self.hireHall:initialize(g_currentMission.missionInfo)
+        end
     end
 
     if self.workerSystem then
@@ -140,6 +155,9 @@ end
 function WorkerManager:update(dt)
     if self.workerSystem then
         self.workerSystem:update(dt)
+    end
+    if self.hireHall then
+        self.hireHall:update(dt)   -- host-only; drives the time-sliced evolution engine
     end
     if self.rosterPanel then
         self.rosterPanel:update()
@@ -176,6 +194,12 @@ function WorkerManager:saveWorkerData(missionInfo)
     end
     missionInfo = missionInfo or (g_currentMission and g_currentMission.missionInfo)
     self.workerRoster:save(missionInfo)
+
+    -- HireHallCore lifecycle state persists alongside the roster, into its own
+    -- isolated hireHallCore.xml (a bad write here can never corrupt the roster file).
+    if self.hireHall then
+        self.hireHall:save(missionInfo)
+    end
 end
 
 function WorkerManager:loadWorkerData()
@@ -566,6 +590,13 @@ function WorkerManager:delete()
     -- accumulate across mission reloads.
     if self.jobTracker then
         self.jobTracker:delete()
+    end
+
+    -- HireHallCore is a sourced-once global singleton: reset its per-mission state
+    -- (corruption flag, event listeners, evolution cursor) so the next career
+    -- starts clean.
+    if self.hireHall and self.hireHall.shutdown then
+        self.hireHall:shutdown()
     end
 
     if self.rosterPanel then

--- a/src/WorkerManager.lua
+++ b/src/WorkerManager.lua
@@ -31,6 +31,15 @@ local WorkerManager_mt = Class(WorkerManager)
 -- candidates the player can hire from the Farm Tablet Personnel app. Candidate
 -- names come from this pool (no text-input field on a controller-friendly tablet).
 WorkerManager.RECRUIT_POOL_SIZE = 4
+
+-- #69 Daily hiring limit: at most this many new hires from the Hiring Hall per
+-- in-game day. Server-authoritative; the counter resets on the day rollover.
+WorkerManager.DAILY_HIRE_LIMIT = 5
+
+-- #68 Progression-gated hiring: total accrued roster XP required before the recruit
+-- roller will offer Experienced candidates. "Master" is NEVER offered in the pool —
+-- it is earned exclusively through XP on the job (WorkerRoster.XP_MASTER).
+WorkerManager.EXPERIENCED_UNLOCK_XP = 80
 local RECRUIT_NAME_POOL = {
     "Alex", "Sam", "Jordan", "Casey", "Riley", "Morgan", "Taylor", "Jamie",
     "Drew", "Quinn", "Avery", "Parker", "Reese", "Skyler", "Hayden", "Rowan",
@@ -214,17 +223,38 @@ end
 -- Pro-Staff Phase 5: recruitment pool (server-authoritative)
 -- =========================================================
 
--- Roll a single recruit. Level is weighted toward Novice; the occasional
--- Experienced/Master recruit costs more to sign (computeHireCost scales by level).
+-- #68 Total XP across the whole roster — the "farm progression" signal that gates
+-- which tiers the Hiring Hall will offer. Rises as the player's staff put in hours.
+function WorkerManager:_totalRosterXP()
+    local sum = 0
+    if self.workerRoster then
+        for _, w in ipairs(self.workerRoster:getAll()) do
+            sum = sum + (w.totalXP or 0)
+        end
+    end
+    return sum
+end
+
+-- #68 The highest tier the recruit roller may currently offer. Master is never
+-- recruitable (earned via XP only); Experienced unlocks once the farm has invested
+-- enough total staff XP. Novice is always available.
+function WorkerManager:_maxRecruitTier()
+    if self:_totalRosterXP() >= WorkerManager.EXPERIENCED_UNLOCK_XP then
+        return WorkerRoster.LEVEL_EXPERIENCED
+    end
+    return WorkerRoster.LEVEL_NOVICE
+end
+
+-- Roll a single recruit. Level is weighted toward Novice; an Experienced recruit
+-- costs more to sign (computeHireCost scales by level). Master is intentionally
+-- excluded from the pool entirely (#68 — it is an earned milestone, not a hire).
 function WorkerManager:_generateRecruit()
-    local r = math.random()
-    local level
-    if r < 0.70 then
-        level = WorkerRoster.LEVEL_NOVICE
-    elseif r < 0.93 then
-        level = WorkerRoster.LEVEL_EXPERIENCED
-    else
-        level = WorkerRoster.LEVEL_MASTER
+    local level = WorkerRoster.LEVEL_NOVICE
+    if self:_maxRecruitTier() >= WorkerRoster.LEVEL_EXPERIENCED then
+        -- ~20% Experienced once unlocked; the rest stay Novice.
+        if math.random() < 0.20 then
+            level = WorkerRoster.LEVEL_EXPERIENCED
+        end
     end
 
     local name = RECRUIT_NAME_POOL[math.random(1, #RECRUIT_NAME_POOL)]
@@ -286,10 +316,18 @@ function WorkerManager:getServerSnapshot()
             estIntervalCost = (workerSys and workerSys.getEstimatedIntervalCost and workerSys:getEstimatedIntervalCost()) or 0,
             proStaffDelta   = 0,   -- summed below
         },
+        -- #69 Daily hiring quota, so the FarmTablet/clients can show "x of 5 today".
+        hiring = {
+            limit     = WorkerManager.DAILY_HIRE_LIMIT,
+            usedToday = self:getHiresUsedToday(),
+            remaining = math.max(0, WorkerManager.DAILY_HIRE_LIMIT - self:getHiresUsedToday()),
+        },
     }
 
     if self.workerRoster then
-        for _, w in ipairs(self.workerRoster:getAll()) do
+        -- #67 Trusted workers sort to the top here too, so every consumer (panel,
+        -- tablet, MP client) shows the same favorite-first ordering.
+        for _, w in ipairs(self.workerRoster:getDisplayOrder()) do
             local isWorking = w.assignedVehicleId ~= nil
             local isPinned  = w.assignedVehicleUniqueId ~= nil
             local status    = isWorking and "working" or "idle"
@@ -329,6 +367,7 @@ function WorkerManager:getServerSnapshot()
                 fatigue    = fatigue,   -- 0..1
                 working    = isWorking,
                 pinned     = isPinned,
+                trusted    = w.trusted == true,
                 status     = status,
                 baseRate   = baseRate,
                 effRate    = effRate,
@@ -373,6 +412,7 @@ function WorkerManager:getRosterSnapshot()
         workers = {},
         recruits = {},
         finance = {},
+        hiring  = { limit = WorkerManager.DAILY_HIRE_LIMIT, usedToday = 0, remaining = WorkerManager.DAILY_HIRE_LIMIT },
     }
 end
 
@@ -408,6 +448,12 @@ function WorkerManager:unassignWorker(uuid)
     WCNetwork_SendCommand(WCCommand.UNASSIGN, uuid or 0, 0, "", 0)
 end
 
+-- #67 Mark/unmark a worker as a Trusted ("favorite") employee. The desired state
+-- rides in the slot field (1 = trusted, 0 = not) — no new wire field needed.
+function WorkerManager:setTrusted(uuid, trusted)
+    WCNetwork_SendCommand(WCCommand.SET_TRUSTED, uuid or 0, trusted and 1 or 0, "", 0)
+end
+
 function WorkerManager:refreshRecruits()
     WCNetwork_SendCommand(WCCommand.REFRESH_POOL, 0, 0, "", 0)
 end
@@ -417,17 +463,27 @@ end
 function WorkerManager:_applyCommandFromNetwork(action, uuid, slot, vehicleUniqueId, farmId)
     if not self.workerRoster then return end
 
+    -- Each _doX returns false when nothing actually changed (e.g. a hire blocked by
+    -- the daily cap, or a missing worker), so we skip the save + client broadcast for
+    -- a no-op. nil/true both count as "changed" to keep the existing actions simple.
+    local changed
     if action == WCCommand.HIRE then
-        self:_doHire(slot, farmId)
+        changed = self:_doHire(slot, farmId)
     elseif action == WCCommand.FIRE then
-        self:_doFire(uuid, farmId)
+        changed = self:_doFire(uuid, farmId)
     elseif action == WCCommand.ASSIGN then
-        self:_doAssign(uuid, vehicleUniqueId)
+        changed = self:_doAssign(uuid, vehicleUniqueId)
     elseif action == WCCommand.UNASSIGN then
-        self:_doUnassign(uuid)
+        changed = self:_doUnassign(uuid)
+    elseif action == WCCommand.SET_TRUSTED then
+        changed = self:_doSetTrusted(uuid, slot)
     elseif action == WCCommand.REFRESH_POOL then
         self:refreshRecruitPool()
     else
+        return
+    end
+
+    if changed == false then
         return
     end
 
@@ -435,12 +491,48 @@ function WorkerManager:_applyCommandFromNetwork(action, uuid, slot, vehicleUniqu
     self:_broadcastRosterSync()
 end
 
+-- Current in-game day (FS25 sandbox: no os.time). -1 default forces a rollover.
+function WorkerManager:_currentDay()
+    return (g_currentMission and g_currentMission.environment
+        and g_currentMission.environment.currentDay) or 0
+end
+
+-- #69 Roll the daily-hire counter over to today if a new in-game day has started.
+function WorkerManager:_rolloverHireDay()
+    local roster = self.workerRoster
+    local today = self:_currentDay()
+    if roster.lastHireDay ~= today then
+        roster.hiredToday  = 0
+        roster.lastHireDay = today
+    end
+end
+
+-- #69 Hires already used today (0 if the stored day is stale / a new day began).
+function WorkerManager:getHiresUsedToday()
+    local roster = self.workerRoster
+    if not roster then return 0 end
+    if roster.lastHireDay ~= self:_currentDay() then
+        return 0
+    end
+    return roster.hiredToday or 0
+end
+
 function WorkerManager:_doHire(slot, farmId)
     local pool = self:getRecruitPool()
     slot = slot or 1
     local cand = pool[slot]
     if not cand then
-        return
+        return false
+    end
+
+    -- #69 Daily hiring cap (server-authoritative). Reset on the day rollover, then
+    -- reject once the limit is reached so the save can't be bypassed by reloading.
+    self:_rolloverHireDay()
+    if (self.workerRoster.hiredToday or 0) >= WorkerManager.DAILY_HIRE_LIMIT then
+        self:_notifyHireLimit()
+        Logging.info("[Worker Costs] Hire blocked — daily limit (%d) reached",
+            WorkerManager.DAILY_HIRE_LIMIT)
+        return false
     end
 
     if self.workerSystem then
@@ -449,6 +541,7 @@ function WorkerManager:_doHire(slot, farmId)
 
     local w = self.workerRoster:createWorker(cand.name)
     -- Seed XP so the recruit's advertised level holds after recomputeLevel().
+    -- (Master is never offered by the roller — #68 — so that branch is defensive.)
     if cand.level == WorkerRoster.LEVEL_EXPERIENCED then
         w.totalXP = WorkerRoster.XP_EXPERIENCED
     elseif cand.level == WorkerRoster.LEVEL_MASTER then
@@ -456,34 +549,65 @@ function WorkerManager:_doHire(slot, farmId)
     end
     self.workerRoster:recomputeLevel(w)
 
+    -- Count this hire against today's quota (#69).
+    self.workerRoster.hiredToday = (self.workerRoster.hiredToday or 0) + 1
+
     -- Consume the slot and refill so the pool always offers a full set.
     table.remove(pool, slot)
     table.insert(pool, self:_generateRecruit())
 
-    Logging.info("[Worker Costs] Hired %s (level %d, id=%d)", cand.name, cand.level, w.uuid)
+    Logging.info("[Worker Costs] Hired %s (level %d, id=%d) — %d/%d today",
+        cand.name, cand.level, w.uuid, self.workerRoster.hiredToday, WorkerManager.DAILY_HIRE_LIMIT)
+    return true
+end
+
+-- #69 Player feedback when the daily hire limit is hit (host/SP HUD toast; MP
+-- clients see the remaining count in the synced snapshot).
+function WorkerManager:_notifyHireLimit()
+    if g_currentMission and g_currentMission.hud and g_currentMission.hud.showBlinkingWarning then
+        g_currentMission.hud:showBlinkingWarning(
+            "Daily hiring limit reached. Please wait for the next day.", 4000)
+    end
 end
 
 function WorkerManager:_doFire(uuid, farmId)
     local w = self.workerRoster:getWorker(uuid)
     if not w then
-        return
+        return false
     end
     if self.workerSystem then
         self.workerSystem:chargeSeverance(w.name or "Worker", w.level, farmId)
     end
     self.workerRoster:removeWorker(uuid)
     Logging.info("[Worker Costs] Fired worker id=%d", uuid)
+    return true
 end
 
 function WorkerManager:_doAssign(uuid, vehicleUniqueId)
     if not vehicleUniqueId or vehicleUniqueId == "" then
-        return
+        return false
     end
-    self.workerRoster:assignVehiclePersistent(uuid, vehicleUniqueId)
+    return self.workerRoster:assignVehiclePersistent(uuid, vehicleUniqueId)
 end
 
 function WorkerManager:_doUnassign(uuid)
-    self.workerRoster:unassignPersistent(uuid)
+    return self.workerRoster:unassignPersistent(uuid)
+end
+
+-- #67 Toggle a worker's Trusted/favorite flag. slot carries the desired state (1/0)
+-- so the existing command channel needs no new wire field.
+function WorkerManager:_doSetTrusted(uuid, slot)
+    local w = self.workerRoster:getWorker(uuid)
+    if not w then
+        return false
+    end
+    local wantTrusted = (slot == 1)
+    if w.trusted == wantTrusted then
+        return false   -- no change, no broadcast
+    end
+    w.trusted = wantTrusted
+    Logging.info("[Worker Costs] Worker id=%d trusted=%s", uuid, tostring(wantTrusted))
+    return true
 end
 
 -- Push the fresh snapshot to all clients after a mutation (no-op in SP).

--- a/src/WorkerRoster.lua
+++ b/src/WorkerRoster.lua
@@ -59,6 +59,12 @@ function WorkerRoster.new()
     self.workers = {}   -- array, insertion order (stable for UI lists)
     self.byId    = {}   -- [uuid] -> worker, O(1) lookup
     self.nextId  = 1    -- monotonic, never reused; persisted so ids survive reload
+    -- Hiring-Hall daily-cap state (#69). Stored in this mod's career file
+    -- (workerData.xml) because it is per-career, server-authoritative hall state;
+    -- the WorkerManager owns the policy (limit + day rollover), the roster just
+    -- persists the two scalars.
+    self.hiredToday  = 0
+    self.lastHireDay = -1
     return self
 end
 
@@ -84,6 +90,9 @@ function WorkerRoster.newWorker(uuid, name)
         -- player pinned this worker to. Saved; survives reload. Re-binds naturally
         -- when a job starts on that vehicle (its uniqueId matches).
         assignedVehicleUniqueId = nil,
+        -- "Trusted Employee" favorite flag (#67). Trusted workers sort to the top of
+        -- the roster lists. Persistent; survives save/reload.
+        trusted = false,
     }
 end
 
@@ -110,6 +119,33 @@ end
 
 function WorkerRoster:getCount()
     return #self.workers
+end
+
+--- O(1) existence check by uuid. FR5's job monitor calls this as a hard guard
+--- before writing history, so an orphaned (fired-in-same-frame) worker is skipped.
+function WorkerRoster:getWorkerExists(uuid)
+    return uuid ~= nil and self.byId[uuid] ~= nil
+end
+
+--- A display-ordered VIEW of the roster (#67): Trusted ("favorite") workers first,
+--- then the rest, each group preserving stable insertion order (uuid is monotonic).
+--- Returns a fresh array — never the live self.workers — so callers can't reorder
+--- the canonical list. Used by the roster panel and the snapshot so every surface
+--- shows trusted staff pinned to the top.
+function WorkerRoster:getDisplayOrder()
+    local list = {}
+    for i = 1, #self.workers do
+        list[i] = self.workers[i]
+    end
+    table.sort(list, function(a, b)
+        local ta = a.trusted and 1 or 0
+        local tb = b.trusted and 1 or 0
+        if ta ~= tb then
+            return ta > tb            -- trusted (1) ahead of untrusted (0)
+        end
+        return (a.uuid or 0) < (b.uuid or 0)   -- stable: insertion/hire order
+    end)
+    return list
 end
 
 --- Fire: remove a worker by id. Returns true if one was removed.
@@ -224,6 +260,8 @@ function WorkerRoster:clear()
     self.workers = {}
     self.byId    = {}
     self.nextId  = 1
+    self.hiredToday  = 0
+    self.lastHireDay = -1
 end
 
 -- ---------------------------------------------------------------------------
@@ -304,6 +342,9 @@ function WorkerRoster:save(missionInfo)
     xmlFile:setString(root .. "#version", WorkerRoster.SCHEMA_VERSION)
     xmlFile:setInt(root .. "#nextId", self.nextId)
     xmlFile:setInt(root .. "#count", #self.workers)
+    -- Hiring-Hall daily-cap state (#69) — per-career hall state in this same file.
+    xmlFile:setInt(root .. "#hiredToday", self.hiredToday or 0)
+    xmlFile:setInt(root .. "#lastHireDay", self.lastHireDay or -1)
 
     for i, w in ipairs(self.workers) do
         local key = string.format("%s.worker(%d)", root, i - 1)
@@ -319,6 +360,10 @@ function WorkerRoster:save(missionInfo)
         -- is still NOT saved (a runtime pointer is meaningless next session).
         if w.assignedVehicleUniqueId then
             xmlFile:setString(key .. "#assignedVehicleUniqueId", w.assignedVehicleUniqueId)
+        end
+        -- Trusted/favorite flag (#67). Only written when set, to keep files small.
+        if w.trusted then
+            xmlFile:setBool(key .. "#trusted", true)
         end
     end
 
@@ -347,6 +392,10 @@ function WorkerRoster:loadIfExists(missionInfo)
 
     local root = WorkerRoster.SAVE_ROOT
     local savedNextId = xmlFile:getInt(root .. "#nextId", 1)
+    -- Hiring-Hall daily-cap state (#69). Defaults keep a pre-#69 save uncapped on
+    -- its first day (lastHireDay = -1 forces a rollover-reset on the next hire).
+    self.hiredToday  = xmlFile:getInt(root .. "#hiredToday", 0)
+    self.lastHireDay = xmlFile:getInt(root .. "#lastHireDay", -1)
     local maxId = 0
 
     xmlFile:iterate(root .. ".worker", function(_, key)
@@ -365,6 +414,7 @@ function WorkerRoster:loadIfExists(missionInfo)
             hiredDay   = xmlFile:getInt(key .. "#hiredDay", 0),
             assignedVehicleId = nil,  -- transient; re-bound at job start
             assignedVehicleUniqueId = xmlFile:getString(key .. "#assignedVehicleUniqueId", nil),
+            trusted = xmlFile:getBool(key .. "#trusted", false),
         }
         table.insert(self.workers, w)
         self.byId[uuid] = w

--- a/src/gui/WCRosterPanel.lua
+++ b/src/gui/WCRosterPanel.lua
@@ -30,12 +30,15 @@ local C = {
     border = { 0.34, 0.70, 0.42 },     -- green border
     row    = { 0.19, 0.20, 0.22 },     -- grey rows (zebra)
     rowAlt = { 0.23, 0.24, 0.26 },
+    rowTrust = { 0.26, 0.24, 0.14 },   -- warm-tinted row bg for Trusted workers (#67)
     text   = { 0.64, 0.92, 0.70, 1 },  -- green text
     dim    = { 0.50, 0.70, 0.55, 1 },  -- muted green
     accent = { 0.55, 0.95, 0.62, 1 },
+    gold   = { 0.96, 0.80, 0.27, 1 },  -- Trusted star (#67)
     btnHire   = { 0.20, 0.50, 0.28 },  -- green
     btnAssign = { 0.24, 0.42, 0.58 },  -- blue (distinct action)
     btnFire   = { 0.55, 0.24, 0.24 },  -- red (distinct, important)
+    btnStar   = { 0.34, 0.32, 0.18 },  -- dim gold seat for the un-trusted star button
     btnTxt    = { 1, 1, 1, 1 },        -- white on coloured buttons stays readable
 }
 
@@ -59,6 +62,7 @@ local TS_INFO  = 0.0120
 -- Button widths
 local BTN_FIRE_W   = 0.052
 local BTN_ASSIGN_W = 0.090
+local BTN_STAR_W   = 0.026   -- #67 Trusted toggle (leftmost column)
 local BTN_GAP      = 0.008
 
 -- Names used when hiring from the panel (no text-input field in an overlay).
@@ -211,13 +215,22 @@ function WCRosterPanel:drawHireBar()
     local bw = 0.16
     self:drawButton("hire", PX + PAD, by, bw, 0.040, "+ Hire Worker", C.btnHire)
 
+    -- #69 Daily-cap usage next to the hire button (turns gold when the cap is hit).
+    local mgr = g_currentMission and g_currentMission.workerCostsManager
+    local limit = (WorkerManager and WorkerManager.DAILY_HIRE_LIMIT) or 5
+    local used = (mgr and mgr.getHiresUsedToday and mgr:getHiresUsedToday()) or 0
+    self:drawText(PX + PAD + bw + 0.016, by + 0.010, TS_INFO,
+        string.format("Hires today: %d/%d", used, limit),
+        (used >= limit) and C.gold or C.dim, RenderText.ALIGN_LEFT)
+
     -- Right-aligned hint about assigning.
     self:drawText(PX + PW - PAD, by + 0.010, TS_INFO,
         "Sit in a vehicle, then Assign", C.dim, RenderText.ALIGN_RIGHT)
 end
 
 function WCRosterPanel:drawRosterList()
-    local workers = self.roster and self.roster:getAll() or {}
+    -- #67 Trusted ("favorite") workers float to the top via the roster's display view.
+    local workers = self.roster and self.roster:getDisplayOrder() or {}
     local total = #workers
 
     local listTop = PY + PH - TB_H - 0.052 - 0.012   -- below hire bar
@@ -247,28 +260,41 @@ function WCRosterPanel:drawRosterList()
         local w = workers[idx]
         local ry = listTop - ROW_H - (i * ROW_H)
 
-        -- Row background (zebra)
-        self:drawRect(rowX, ry, rowW, ROW_H - 0.004, (i % 2 == 0) and C.row or C.rowAlt)
+        -- Row background — Trusted workers get a warm tint, others keep the zebra (#67)
+        local rowBg = (i % 2 == 0) and C.row or C.rowAlt
+        if w.trusted then rowBg = C.rowTrust end
+        self:drawRect(rowX, ry, rowW, ROW_H - 0.004, rowBg)
+
+        local bh = ROW_H - 0.014
+        local byBtn = ry + 0.005
+
+        -- #67 Trusted toggle (leftmost). "*" reads bright gold when trusted, muted
+        -- when not. (ASCII glyph — guaranteed to render in the engine font.)
+        local starX = rowX + 0.006
+        self:drawRect(starX, byBtn, BTN_STAR_W, bh, C.btnStar)
+        self:drawText(starX + BTN_STAR_W * 0.5, byBtn + bh * 0.20, TS_ROW, "*",
+            w.trusted and C.gold or C.dim, RenderText.ALIGN_CENTER, true)
+        self:registerClick("star_" .. w.uuid, starX, byBtn, BTN_STAR_W, bh,
+            { uuid = w.uuid, trusted = w.trusted })
+
+        local textX = rowX + 0.006 + BTN_STAR_W + 0.010
 
         -- Status / level color accent dot via level color
         local levelName = WorkerRoster.levelName(w.level)
         local status = w.assignedVehicleId and "working" or "idle"
         if w.assignedVehicleUniqueId then status = status .. ", pinned" end
+        if w.trusted then status = status .. ", trusted" end
 
         -- Line 1: name + level
-        self:drawText(rowX + 0.008, ry + ROW_H * 0.50, TS_ROW,
+        self:drawText(textX, ry + ROW_H * 0.50, TS_ROW,
             string.format("%s  -  %s", w.name or "Worker", levelName),
             C.text, RenderText.ALIGN_LEFT, true)
         -- Line 2: stats
-        self:drawText(rowX + 0.008, ry + ROW_H * 0.16, TS_INFO,
+        self:drawText(textX, ry + ROW_H * 0.16, TS_INFO,
             string.format("%.1fh  -  %d jobs  -  fat %d%%  -  %s",
                 w.totalHours or 0, w.totalJobs or 0,
                 math.floor((w.fatigue or 0) * 100), status),
             C.dim, RenderText.ALIGN_LEFT)
-
-        -- Buttons
-        local bh = ROW_H - 0.014
-        local byBtn = ry + 0.005
         if w.assignedVehicleUniqueId then
             self:drawButton("unassign_" .. w.uuid, assignX, byBtn, BTN_ASSIGN_W, bh,
                 "Unassign", C.btnAssign, { uuid = w.uuid })
@@ -367,16 +393,31 @@ function WCRosterPanel:handleClick(id, data)
 
     if id == "hire" then
         if mgr then
+            -- #69 Respect the daily cap with immediate panel feedback (the host also
+            -- enforces it server-side, so this is UX, not the security boundary).
+            local limit = WorkerManager and WorkerManager.DAILY_HIRE_LIMIT or 5
+            if mgr.getHiresUsedToday and mgr:getHiresUsedToday() >= limit then
+                self.infoMsg = "Daily hiring limit reached - wait for the next day"
+                return
+            end
             local pool = mgr:getRecruitPool()
             local cand = pool and pool[1]
             mgr:hireWorker(1)
             if cand then
                 local money = g_i18n and g_i18n:formatMoney(cand.hireCost or 0, 0, true, true) or ("$" .. (cand.hireCost or 0))
-                self.infoMsg = string.format("Hired %s  (signing %s)", cand.name, money)
+                local used = (mgr.getHiresUsedToday and mgr:getHiresUsedToday()) or 0
+                self.infoMsg = string.format("Hired %s  (signing %s)  -  %d/%d today",
+                    cand.name, money, used, limit)
             else
                 self.infoMsg = "No recruits available"
             end
         end
+
+    elseif id:sub(1, 5) == "star_" and data then
+        -- #67 Toggle the Trusted/favorite flag (routes through the command API so
+        -- the host broadcasts and the change persists).
+        if mgr then mgr:setTrusted(data.uuid, not data.trusted) end
+        self.infoMsg = data.trusted and "Removed from Trusted" or "Marked as Trusted"
 
     elseif id:sub(1, 5) == "fire_" and data then
         if mgr then

--- a/src/hireHallCore/HireHallCore.lua
+++ b/src/hireHallCore/HireHallCore.lua
@@ -1,0 +1,272 @@
+-- =========================================================
+-- FS25 Realistic Worker Costs Mod
+-- =========================================================
+-- HireHallCore — framework foundation & engineering controls (FR0)
+-- =========================================================
+-- Author: TisonK
+-- =========================================================
+-- COPYRIGHT NOTICE:
+-- All rights reserved. Unauthorized redistribution, copying,
+-- or claiming this code as your own is strictly prohibited.
+-- Original author: TisonK
+-- =========================================================
+--
+-- WHAT THIS IS
+--   The authoritative HireHallCore orchestrator. It owns the framework-wide
+--   constants, the bitwise dirty-mask helpers, the silent-failure / corruption
+--   policy, the host-authority gate, and the per-frame entry point that drives
+--   the time-sliced evolution engine. Every other hireHallCore module attaches
+--   itself to this single global namespace.
+--
+-- DESIGN RECONCILIATIONS (the FR specs are written by a non-implementer and
+-- contradict themselves in spots; the resolved decisions live here):
+--   * Per-worker data namespace: the spec says both `worker.hireHall` (FR0) and
+--     `worker.hireHallMeta` (FR1/FR3/FR4). We use ONE table — `worker.hireHallMeta`
+--     — created lazily via the FR0 "if not ... then" isolation guard, so the
+--     roster's own fields/save format are never touched.
+--   * Lifecycle field name: FR1's init snippet says `.lifecycle`, but FR1's
+--     property-injection directive AND FR3 condition 1 both say `.lifecycleState`.
+--     Two votes to one — we standardize on `lifecycleState`.
+--   * Host authority: the spec mandates `g_currentMission.isMasterUser`. That field
+--     is false on a dedicated server (no local admin), yet the roster lives on the
+--     server. Using it would break dedicated MP. The roster is server-authoritative,
+--     so we gate on getIsServer() and keep the spec's NOT_HOST / CLIENT_READ_ONLY
+--     reason codes. (Verified: FarmlandManager uses `getIsServer() or isMasterUser`.)
+--   * Fatigue scale: the roster stores fatigue 0..1; the spec compares against 95.
+--     The FR2 telemetry accessor normalizes to a 0..100 percentage so broker code
+--     reads like the spec ("< 95").
+-- =========================================================
+
+---@class HireHallCore
+HireHallCore = HireHallCore or {}
+
+-- ---------------------------------------------------------------------------
+-- Engineering constants (FR0)
+-- ---------------------------------------------------------------------------
+
+-- Bitwise dirty masks (single-bit power-of-two flags). Set when a worker needs
+-- UI / history / hall reprocessing; cleared once the relevant module consumes it.
+HireHallCore.DIRTY_UI      = 1   -- 001
+HireHallCore.DIRTY_HISTORY = 2   -- 010
+HireHallCore.DIRTY_HALL    = 4   -- 100
+
+HireHallCore.SLICE_SIZE     = 5    -- workers processed per evolution step (FR4)
+HireHallCore.STEP_INTERVAL  = 250  -- ms between evolution steps; keeps cost << 0.05ms/frame
+HireHallCore.SCHEMA_VERSION = 1    -- <hireHallCore version="1"> (FR0 / FR14)
+
+-- Lifecycle states (FR1). Pre-defined string constants so transitions never
+-- allocate a temporary (zero-allocation directive).
+HireHallCore.STATE = {
+    AVAILABLE = "available",
+    HIRED     = "hired",
+    TRAINING  = "training",
+    INJURED   = "injured",
+    ON_LEAVE  = "onLeave",
+    RETIRED   = "retired",
+    FIRED     = "fired",
+    CONTRACT  = "contract",
+}
+
+-- O(1) validity set for the FR1 invalid-state guard.
+HireHallCore.VALID_STATE = {}
+for _, s in pairs(HireHallCore.STATE) do
+    HireHallCore.VALID_STATE[s] = true
+end
+
+-- Fatigue thresholds, all on the FR2 0..100 telemetry scale.
+HireHallCore.FATIGUE_DISPATCH_MAX = 95   -- FR3 cond.2: not dispatchable at/above this
+HireHallCore.FATIGUE_LEAVE_AT     = 95   -- FR1/FR4: mandatory onLeave at/above this
+HireHallCore.FATIGUE_RECOVER_TO   = 30   -- FR4: onLeave -> available once rested below this
+
+-- Sub-namespaces. Created here so module load order is forgiving: each file does
+-- `HireHallCore.core = HireHallCore.core or {}` and attaches itself.
+HireHallCore.core        = HireHallCore.core or {}
+HireHallCore.integration = HireHallCore.integration or {}
+
+-- ---------------------------------------------------------------------------
+-- Runtime state
+-- ---------------------------------------------------------------------------
+HireHallCore.isCorrupted  = false   -- set by the silent-failure policy; halts the subsystem
+HireHallCore._initialized = false
+HireHallCore._toastShown  = false
+HireHallCore._stepTimer   = 0
+
+-- ---------------------------------------------------------------------------
+-- Bitwise helpers (FR0). Prefer the engine ops (bitOR/bitAND, verified in the
+-- LUADOC engine/Math reference); fall back to pure-Lua arithmetic for power-of-two
+-- flags so the module is also correct/testable outside the in-game sandbox.
+-- ---------------------------------------------------------------------------
+local _bor = bitOR or function(a, b)
+    local res, bit = 0, 1
+    local hi = math.max(a, b)
+    while bit <= hi do
+        if (math.floor(a / bit) % 2 == 1) or (math.floor(b / bit) % 2 == 1) then
+            res = res + bit
+        end
+        bit = bit * 2
+    end
+    return res
+end
+
+local _band = bitAND or function(a, b)
+    local res, bit = 0, 1
+    local hi = math.min(a, b)
+    while bit <= hi do
+        if (math.floor(a / bit) % 2 == 1) and (math.floor(b / bit) % 2 == 1) then
+            res = res + bit
+        end
+        bit = bit * 2
+    end
+    return res
+end
+
+function HireHallCore.maskHas(mask, flag)
+    return _band(mask or 0, flag) ~= 0
+end
+
+function HireHallCore.maskSet(mask, flag)
+    return _bor(mask or 0, flag)
+end
+
+function HireHallCore.maskClear(mask, flag)
+    local m = mask or 0
+    if HireHallCore.maskHas(m, flag) then
+        return m - flag   -- single-bit flag: subtract is exact
+    end
+    return m
+end
+
+-- ---------------------------------------------------------------------------
+-- Host authority (FR0). The roster is server-authoritative; only the host owns
+-- real worker objects. See the dedicated-server note in the header.
+-- ---------------------------------------------------------------------------
+function HireHallCore._isHost()
+    return g_currentMission ~= nil
+        and g_currentMission.getIsServer ~= nil
+        and g_currentMission:getIsServer()
+end
+
+-- ---------------------------------------------------------------------------
+-- Silent-failure & integrity policy (FR0). One corruption flag halts the whole
+-- subsystem for the session; a single System Error toast informs the player.
+-- ---------------------------------------------------------------------------
+
+-- Fire the FarmTablet "System Error" toast once per session. The FarmTablet app is
+-- Phase 4 (FR13); until it exists we degrade gracefully to the HUD warning + log.
+function HireHallCore:fireSystemErrorToast(msg)
+    if self._toastShown then
+        return
+    end
+    self._toastShown = true
+    if g_currentMission and g_currentMission.hud and g_currentMission.hud.showBlinkingWarning then
+        pcall(function()
+            g_currentMission.hud:showBlinkingWarning(msg or "HireHallCore: personnel subsystem error", 5000)
+        end)
+    end
+end
+
+-- Trip the corruption flag, log the cause, fire the one-shot toast, halt operations.
+function HireHallCore:fail(context, err)
+    self.isCorrupted = true
+    Logging.error("[HireHallCore] %s: %s", tostring(context), tostring(err))
+    self:fireSystemErrorToast("HireHallCore error — personnel lifecycle suspended")
+end
+
+-- Run a sensitive op under pcall (FR0). On failure: corrupt + halt. Returns
+-- ok(bool), plus the wrapped call's first two results on success.
+function HireHallCore:guard(context, fn)
+    if self.isCorrupted then
+        return false
+    end
+    local ok, a, b = pcall(fn)
+    if not ok then
+        self:fail(context, a)
+        return false
+    end
+    return true, a, b
+end
+
+-- ---------------------------------------------------------------------------
+-- Lifecycle wiring (called by WorkerManager — the coordinator)
+-- ---------------------------------------------------------------------------
+
+--- Bind the framework to the mod's subsystems. Idempotent; the global IS the
+--- singleton, so a stored reference (WorkerManager.hireHall) just aliases it.
+function HireHallCore:setup(roster, settings, workerSystem, jobTracker)
+    self.roster       = roster
+    self.settings     = settings
+    self.workerSystem = workerSystem
+    self.jobTracker   = jobTracker
+    self.isCorrupted  = false
+    self._toastShown  = false
+    self._initialized = false
+    self._stepTimer   = 0
+    return self
+end
+
+--- Initialize on the host once the roster has loaded: give every worker a meta
+--- block (default available), then apply any persisted lifecycle states.
+function HireHallCore:initialize(missionInfo)
+    if not HireHallCore._isHost() then
+        return   -- clients have no real roster; they read synced snapshots (Phase 4)
+    end
+
+    self:guard("initialize", function()
+        if self.roster then
+            for _, w in ipairs(self.roster:getAll()) do
+                HireHallCore.core.Lifecycle:ensureMeta(w)
+            end
+        end
+        if HireHallCore.Schema then
+            HireHallCore.Schema:loadIfExists(missionInfo, self.roster)
+        end
+    end)
+
+    self._initialized = true
+    Logging.info("[HireHallCore] Initialized (host) — lifecycle layer active")
+end
+
+--- Per-frame entry point (host only). Drives the time-sliced evolution engine.
+function HireHallCore:update(dt)
+    if not HireHallCore._isHost() then
+        return
+    end
+    if self.isCorrupted or not self._initialized then
+        return
+    end
+    HireHallCore.core.Evolution:update(self, dt)
+end
+
+--- Persist lifecycle state (host only) into the isolated <hireHallCore> file.
+function HireHallCore:save(missionInfo)
+    if not HireHallCore._isHost() then
+        return
+    end
+    self:guard("save", function()
+        if HireHallCore.Schema then
+            HireHallCore.Schema:save(missionInfo, self.roster)
+        end
+    end)
+end
+
+--- Reset per-mission state on unload. The global persists across mission reloads
+--- (source() runs once), so this prevents stale corruption flags / event listeners
+--- / evolution cursors from leaking into the next session.
+function HireHallCore:shutdown()
+    self.isCorrupted  = false
+    self._initialized = false
+    self._toastShown  = false
+    self._stepTimer   = 0
+    if HireHallCore.core.Evolution and HireHallCore.core.Evolution.reset then
+        HireHallCore.core.Evolution:reset()
+    end
+    if HireHallCore.Events and HireHallCore.Events.clear then
+        HireHallCore.Events:clear()
+    end
+    self.roster       = nil
+    self.settings     = nil
+    self.workerSystem = nil
+    self.jobTracker   = nil
+end
+
+getfenv(0)["HireHallCore"] = HireHallCore

--- a/src/hireHallCore/HireHallCore.lua
+++ b/src/hireHallCore/HireHallCore.lua
@@ -52,7 +52,8 @@ HireHallCore.DIRTY_HALL    = 4   -- 100
 
 HireHallCore.SLICE_SIZE     = 5    -- workers processed per evolution step (FR4)
 HireHallCore.STEP_INTERVAL  = 250  -- ms between evolution steps; keeps cost << 0.05ms/frame
-HireHallCore.SCHEMA_VERSION = 1    -- <hireHallCore version="1"> (FR0 / FR14)
+HireHallCore.HISTORY_CAP    = 20   -- max job-result rows kept per worker (FR5 circular buffer)
+HireHallCore.SCHEMA_VERSION = 2    -- <hireHallCore version="2"> — v2 adds per-worker history (FR5)
 
 -- Lifecycle states (FR1). Pre-defined string constants so transitions never
 -- allocate a temporary (zero-allocation directive).
@@ -222,6 +223,12 @@ function HireHallCore:initialize(missionInfo)
         end
     end)
 
+    -- Arm the FR5 job-termination monitor now the framework + roster are live
+    -- (deferred registration — never bind against nil references).
+    if HireHallCore.integration.JobMonitor then
+        HireHallCore.integration.JobMonitor:install()
+    end
+
     self._initialized = true
     Logging.info("[HireHallCore] Initialized (host) — lifecycle layer active")
 end
@@ -259,6 +266,9 @@ function HireHallCore:shutdown()
     self._stepTimer   = 0
     if HireHallCore.core.Evolution and HireHallCore.core.Evolution.reset then
         HireHallCore.core.Evolution:reset()
+    end
+    if HireHallCore.integration.JobMonitor and HireHallCore.integration.JobMonitor.reset then
+        HireHallCore.integration.JobMonitor:reset()   -- re-armed on next initialize()
     end
     if HireHallCore.Events and HireHallCore.Events.clear then
         HireHallCore.Events:clear()

--- a/src/hireHallCore/core/HireHallAPI.lua
+++ b/src/hireHallCore/core/HireHallAPI.lua
@@ -1,0 +1,131 @@
+-- =========================================================
+-- FS25 Realistic Worker Costs Mod
+-- =========================================================
+-- HireHallCore.core.API — compound availability broker & public API (FR3)
+-- =========================================================
+-- Author: TisonK
+-- =========================================================
+-- COPYRIGHT NOTICE:
+-- All rights reserved. Unauthorized redistribution, copying,
+-- or claiming this code as your own is strictly prohibited.
+-- Original author: TisonK
+-- =========================================================
+--
+-- WHAT THIS IS
+--   The single source of truth for "can this worker be dispatched?" (FR3) plus the
+--   small public surface other layers (the Phase 4 FarmTablet, console commands)
+--   call. isWorkerAvailable() is O(1), allocates nothing, and short-circuits on the
+--   first failing condition so an injured worker never costs a fatigue/idle check.
+--
+--   Evaluation order (strict short-circuit):
+--     0. host authority         -> CLIENT_READ_ONLY
+--     0. corruption / no roster  -> SYSTEM_ERROR
+--     0. unknown id              -> INVALID_WORKER_ID
+--     1. lifecycleState=available-> NOT_AVAILABLE
+--     2. fatigue < 95            -> FATIGUED   (skipped on telemetry drift: treat available)
+--     3. idle (no live job)      -> BUSY
+--     4. pinned-but-parked is still available (FR3 vehicle-pinning rule)
+-- =========================================================
+
+HireHallCore = HireHallCore or {}
+HireHallCore.core = HireHallCore.core or {}
+HireHallCore.core.API = HireHallCore.core.API or {}
+local API = HireHallCore.core.API
+
+-- Idle = not bound to a vehicle on a live AI job right now. Prefer the job
+-- tracker's authoritative view (FR3 cond.3 names WorkerJobTracker:isWorkerIdle);
+-- fall back to the roster's transient binding, which is set for exactly the life
+-- of one AI job. A pinned-but-parked worker has no transient binding -> idle ->
+-- available (FR3 vehicle-pinning rule).
+function API:_isIdle(worker)
+    local tracker = HireHallCore.jobTracker
+    if tracker and tracker.isWorkerIdle then
+        local ok, idle = pcall(function() return tracker:isWorkerIdle(worker.uuid) end)
+        if ok then
+            return idle
+        end
+    end
+    return worker.assignedVehicleId == nil
+end
+
+--- FR3 — the authoritative availability broker. Returns available(bool), reason(string).
+function API:isWorkerAvailable(workerId)
+    -- Read-only on clients (the real roster only exists on the host).
+    if not HireHallCore._isHost() then
+        return false, "CLIENT_READ_ONLY"
+    end
+    if HireHallCore.isCorrupted then
+        return false, "SYSTEM_ERROR"
+    end
+
+    local roster = HireHallCore.roster
+    if roster == nil then
+        return false, "SYSTEM_ERROR"
+    end
+
+    local worker = roster:getWorker(workerId)
+    if worker == nil then
+        Logging.warning("[HireHallCore] isWorkerAvailable: unknown worker id %s", tostring(workerId))
+        return false, "INVALID_WORKER_ID"
+    end
+
+    local Lifecycle = HireHallCore.core.Lifecycle
+    local ProStaff  = HireHallCore.integration.ProStaff
+
+    -- 1. Lifecycle gate — only 'available' permits dispatch.
+    local meta = Lifecycle:ensureMeta(worker)
+    if meta.lifecycleState ~= HireHallCore.STATE.AVAILABLE then
+        return false, "NOT_AVAILABLE"
+    end
+
+    -- 2. Fatigue ceiling. On telemetry drift (FR2 unreadable) DON'T block — the
+    --    FR3 rule is to treat the worker as available rather than lock the workforce.
+    if ProStaff:isReadable(worker) then
+        if ProStaff:getFatigue(worker) >= HireHallCore.FATIGUE_DISPATCH_MAX then
+            return false, "FATIGUED"
+        end
+    end
+
+    -- 3. Task occupancy — must be idle.
+    if not self:_isIdle(worker) then
+        return false, "BUSY"
+    end
+
+    -- 4. Assignment status — pinning alone does not block (covered by step 3).
+    return true, "AVAILABLE"
+end
+
+-- ---------------------------------------------------------------------------
+-- Public, host-checked convenience surface (the FarmTablet/dispatch consume these)
+-- ---------------------------------------------------------------------------
+
+--- Read a worker's lifecycle state string, or nil if unknown.
+function API:getLifecycleState(workerId)
+    local roster = HireHallCore.roster
+    if roster == nil then
+        return nil
+    end
+    local w = roster:getWorker(workerId)
+    if w == nil then
+        return nil
+    end
+    return HireHallCore.core.Lifecycle:getState(w)
+end
+
+--- Request a lifecycle transition (host-authoritative). Returns ok, reasonOrState.
+function API:setLifecycleState(workerId, newState, reason)
+    local roster = HireHallCore.roster
+    if roster == nil then
+        return false, "SYSTEM_ERROR"
+    end
+    local w = roster:getWorker(workerId)
+    if w == nil then
+        return false, "INVALID_WORKER_ID"
+    end
+    return HireHallCore.core.Lifecycle:transition(w, newState, reason)
+end
+
+--- Mark a worker as currently viewed in the UI (front-of-line in the evolver).
+function API:markViewed(workerId)
+    HireHallCore.core.Evolution:pushUrgent(workerId)
+end

--- a/src/hireHallCore/core/HireHallEvents.lua
+++ b/src/hireHallCore/core/HireHallEvents.lua
@@ -1,0 +1,56 @@
+-- =========================================================
+-- FS25 Realistic Worker Costs Mod
+-- =========================================================
+-- HireHallCore.Events — internal reactive event dispatcher (FR1)
+-- =========================================================
+-- Author: TisonK
+-- =========================================================
+-- COPYRIGHT NOTICE:
+-- All rights reserved. Unauthorized redistribution, copying,
+-- or claiming this code as your own is strictly prohibited.
+-- Original author: TisonK
+-- =========================================================
+--
+-- WHAT THIS IS
+--   A tiny in-process pub/sub so the lifecycle state machine can announce
+--   transitions and the UI / logging / history modules react WITHOUT polling
+--   (FR1: HireHallCore.Events:onLifecycleChanged). Listeners are invoked under
+--   pcall so a single bad subscriber can never break the dispatcher (FR0 silent
+--   failure). No subscribers ship in Phase 1 — this is the seam Phase 2/4 plug into.
+-- =========================================================
+
+HireHallCore = HireHallCore or {}
+HireHallCore.Events = HireHallCore.Events or { _listeners = {} }
+local Events = HireHallCore.Events
+
+--- Register a callback for a named event. `fn` is called with the emitted args.
+function Events:subscribe(eventName, fn)
+    if type(eventName) ~= "string" or type(fn) ~= "function" then
+        return
+    end
+    self._listeners[eventName] = self._listeners[eventName] or {}
+    table.insert(self._listeners[eventName], fn)
+end
+
+--- Emit a named event to every subscriber. Each call is isolated by pcall.
+function Events:emit(eventName, ...)
+    local list = self._listeners[eventName]
+    if list == nil then
+        return
+    end
+    for i = 1, #list do
+        pcall(list[i], ...)
+    end
+end
+
+--- The documented lifecycle signal (FR1). Fired by the state machine on every
+--- real transition: (workerId, oldState, newState, reason).
+function Events:onLifecycleChanged(workerId, oldState, newState, reason)
+    self:emit("lifecycleChanged", workerId, oldState, newState, reason)
+end
+
+--- Drop all subscribers (called from HireHallCore:shutdown on mission unload so
+--- listeners don't accumulate across reloads — the global is sourced once).
+function Events:clear()
+    self._listeners = {}
+end

--- a/src/hireHallCore/core/HireHallEvents.lua
+++ b/src/hireHallCore/core/HireHallEvents.lua
@@ -49,6 +49,14 @@ function Events:onLifecycleChanged(workerId, oldState, newState, reason)
     self:emit("lifecycleChanged", workerId, oldState, newState, reason)
 end
 
+--- The job-termination signal (FR5). Fired by WorkerJobTracker when an AI job ends,
+--- carrying the already-resolved facts (workerUuid, hours, startLevel, fatigue, seq,
+--- aiMessage). The Internal Job Termination Monitor is the sole subscriber; this is
+--- the seam that replaces the spec's non-existent WorkerManager.onWorkerEnd hook.
+function Events:onWorkerJobEnded(payload)
+    self:emit("workerJobEnded", payload)
+end
+
 --- Drop all subscribers (called from HireHallCore:shutdown on mission unload so
 --- listeners don't accumulate across reloads — the global is sourced once).
 function Events:clear()

--- a/src/hireHallCore/core/HireHallEvolution.lua
+++ b/src/hireHallCore/core/HireHallEvolution.lua
@@ -1,0 +1,163 @@
+-- =========================================================
+-- FS25 Realistic Worker Costs Mod
+-- =========================================================
+-- HireHallCore.core.Evolution — time-sliced evolution engine (FR4)
+-- =========================================================
+-- Author: TisonK
+-- =========================================================
+-- COPYRIGHT NOTICE:
+-- All rights reserved. Unauthorized redistribution, copying,
+-- or claiming this code as your own is strictly prohibited.
+-- Original author: TisonK
+-- =========================================================
+--
+-- WHAT THIS IS
+--   A bucket-wheel background processor that evolves worker lifecycle state over
+--   time (exhaustion -> onLeave, recovery -> available, injury cooldown -> available)
+--   WITHOUT iterating the whole roster in one frame. It processes at most
+--   SLICE_SIZE (5) workers per step, throttled to ~STEP_INTERVAL, so cost stays
+--   well under the 0.05ms/frame budget even with 200+ workers.
+--
+--   IMPORTANT BOUNDARY: this engine reads fatigue via the FR2 accessor and decides
+--   lifecycle STATE only. It never mutates fatigue/XP — WorkerSystem owns the
+--   fatigue number (daily idle recovery). One owner per datum, no tug-of-war.
+-- =========================================================
+
+HireHallCore = HireHallCore or {}
+HireHallCore.core = HireHallCore.core or {}
+HireHallCore.core.Evolution = HireHallCore.core.Evolution or {
+    lastProcessedIndex = 0,   -- bucket-wheel cursor (0-based; wraps via modulo)
+    lastRosterCount    = 0,   -- detect shrinkage to reset the cursor (FR4)
+    urgentQueue        = {},  -- workerIds viewed in the FarmTablet -> processed first
+}
+local Evolution = HireHallCore.core.Evolution
+
+--- Push a workerId to the front-of-line (FR4 urgent queue). Used when a worker is
+--- being viewed in the FarmTablet (EdgeTabContext; Phase 4) so the UI always sees
+--- fresh state. Small set, deduped in place — no allocation churn.
+function Evolution:pushUrgent(workerId)
+    if workerId == nil then
+        return
+    end
+    for i = 1, #self.urgentQueue do
+        if self.urgentQueue[i] == workerId then
+            return
+        end
+    end
+    self.urgentQueue[#self.urgentQueue + 1] = workerId
+end
+
+--- Reset the wheel (called on shutdown / roster shrinkage).
+function Evolution:reset()
+    self.lastProcessedIndex = 0
+    self.lastRosterCount = 0
+    for i = #self.urgentQueue, 1, -1 do
+        self.urgentQueue[i] = nil
+    end
+end
+
+-- Evolve one worker's lifecycle from its telemetry. Pure state logic; atomic
+-- (a single transition per visit). Never splits a state change across frames.
+function Evolution:_evolveWorker(core, worker)
+    if type(worker) ~= "table" then
+        return
+    end
+    local Lifecycle = HireHallCore.core.Lifecycle
+    local ProStaff  = HireHallCore.integration.ProStaff
+
+    local meta = Lifecycle:ensureMeta(worker)
+    local state    = meta.lifecycleState
+    local readable = ProStaff:isReadable(worker)
+    local fatigue  = ProStaff:getFatigue(worker)   -- 0..100
+    local today    = (g_currentMission and g_currentMission.environment
+        and g_currentMission.environment.currentDay) or 0
+
+    if state == HireHallCore.STATE.INJURED then
+        -- Cooldown elapsed, OR telemetry unreadable -> back to available. FR4 stale
+        -- rule: never leave a worker perpetually injured on a malformed read.
+        if (meta.cooldownEnd ~= nil and today >= meta.cooldownEnd) or not readable then
+            meta.cooldownEnd = nil
+            Lifecycle:transition(worker, HireHallCore.STATE.AVAILABLE, "injury_recovered")
+        end
+    elseif state == HireHallCore.STATE.ON_LEAVE then
+        -- Rested below the recovery floor (or unreadable) -> available again.
+        if not readable or fatigue < HireHallCore.FATIGUE_RECOVER_TO then
+            Lifecycle:transition(worker, HireHallCore.STATE.AVAILABLE, "rested")
+        end
+    elseif state == HireHallCore.STATE.AVAILABLE then
+        -- Mandatory leave once exhausted (FR1 onLeave rule).
+        if readable and fatigue >= HireHallCore.FATIGUE_LEAVE_AT then
+            Lifecycle:transition(worker, HireHallCore.STATE.ON_LEAVE, "exhausted")
+        end
+    end
+    -- training / contract / hired / retired / fired are user/host driven, not auto-evolved.
+
+    -- Debounce (FR4): clear the UI dirty bit now that this worker has been processed.
+    meta.dirtyMask = HireHallCore.maskClear(meta.dirtyMask, HireHallCore.DIRTY_UI)
+end
+
+--- Per-step driver (host only). Throttled to STEP_INTERVAL; processes the urgent
+--- queue, then a SLICE_SIZE bucket-wheel batch. Wrapped in pcall: any error trips
+--- corruption, halts the loop, and fires the single System Error toast (FR4).
+function Evolution:update(core, dt)
+    if not HireHallCore._isHost() then
+        return
+    end
+    local roster = core.roster
+    if roster == nil then
+        return
+    end
+
+    core._stepTimer = (core._stepTimer or 0) + (dt or 0)
+    if core._stepTimer < HireHallCore.STEP_INTERVAL then
+        return
+    end
+    core._stepTimer = 0
+
+    local ok, err = pcall(function()
+        local workers = roster:getAll()
+        local count = #workers
+
+        -- Roster shrinkage guard (FR4): reset the cursor to avoid out-of-bounds.
+        if count ~= self.lastRosterCount then
+            self.lastProcessedIndex = 0
+            self.lastRosterCount = count
+        end
+        if count == 0 then
+            return
+        end
+
+        -- 1. Urgent queue first (UI-visible workers).
+        local uq = self.urgentQueue
+        local uqn = #uq
+        if uqn > 0 then
+            for i = 1, uqn do
+                local w = roster:getWorker(uq[i])
+                if w then
+                    self:_evolveWorker(core, w)
+                end
+            end
+            for i = uqn, 1, -1 do
+                uq[i] = nil   -- clear without allocating a new table
+            end
+        end
+
+        -- 2. Bucket-wheel slice: SLICE_SIZE workers from the cursor (wraps).
+        local slice = HireHallCore.SLICE_SIZE
+        if slice > count then
+            slice = count
+        end
+        for _ = 1, slice do
+            local idx = (self.lastProcessedIndex % count) + 1   -- 1..count
+            self:_evolveWorker(core, workers[idx])
+            self.lastProcessedIndex = self.lastProcessedIndex + 1
+            if self.lastProcessedIndex >= count then
+                self.lastProcessedIndex = 0
+            end
+        end
+    end)
+
+    if not ok then
+        core:fail("evolution.update", err)
+    end
+end

--- a/src/hireHallCore/core/HireHallHistory.lua
+++ b/src/hireHallCore/core/HireHallHistory.lua
@@ -1,0 +1,122 @@
+-- =========================================================
+-- FS25 Realistic Worker Costs Mod
+-- =========================================================
+-- HireHallCore.core.History — per-worker job history circular buffer (FR8)
+-- =========================================================
+-- Author: TisonK
+-- =========================================================
+-- COPYRIGHT NOTICE:
+-- All rights reserved. Unauthorized redistribution, copying,
+-- or claiming this code as your own is strictly prohibited.
+-- Original author: TisonK
+-- =========================================================
+--
+-- WHAT THIS IS
+--   The historical buffer the Internal Job Termination Monitor (FR5) writes to. It
+--   keeps a small, FIFO-capped "professional resume" of recent jobs on each roster
+--   worker's hireHallMeta.history (the slot Lifecycle:ensureMeta already reserves).
+--
+--   The spec (FR5) calls this "HireHallCoreHistory" and asks for "circular buffer
+--   management". A fixed-cap FIFO array IS that: once HISTORY_CAP entries exist, the
+--   oldest is evicted as the newest is appended, so memory is bounded no matter how
+--   many jobs a worker runs over a career.
+--
+-- ENGINEERING CONSTRAINTS HONORED (FR5 checklist)
+--   * Memory: entries store ONLY numbers/strings (day, hours, outcome token, levels,
+--     wage, seq). No vehicle/tool/job table references are ever retained.
+--   * Persistence: the buffer rides along in hireHallCore.xml via HireHallCore.Schema
+--     (segregated file — a bad history write can never corrupt workerData.xml).
+--   * The monitor wraps every record() in HireHallCore:guard(), so a write failure
+--     trips the one corruption flag + single System Error toast rather than throwing.
+-- =========================================================
+
+HireHallCore = HireHallCore or {}
+HireHallCore.core = HireHallCore.core or {}
+HireHallCore.core.History = HireHallCore.core.History or {}
+local History = HireHallCore.core.History
+
+-- Valid outcome tokens (stored as short strings, never localized text).
+History.OUTCOME_COMPLETED = "completed"
+History.OUTCOME_DISMISSED = "dismissed"
+History.OUTCOME_FAILED    = "failed"
+
+History.VALID_OUTCOME = {
+    [History.OUTCOME_COMPLETED] = true,
+    [History.OUTCOME_DISMISSED] = true,
+    [History.OUTCOME_FAILED]    = true,
+}
+
+--- Append a job-result entry to a worker's history, evicting the oldest once the
+--- buffer is full (FIFO circular-buffer behaviour). Sets the HISTORY dirty bit so a
+--- future sync/UI knows the resume changed. Returns the stored entry.
+--- Callers run this under HireHallCore:guard() — keep it allocation-light and pure.
+function History:record(worker, entry)
+    local meta = HireHallCore.core.Lifecycle:ensureMeta(worker)
+    if meta == nil or type(entry) ~= "table" then
+        return nil
+    end
+
+    if meta.history == nil then
+        meta.history = {}
+    end
+    local buf = meta.history
+
+    -- Normalize: keep only the documented numeric/string fields (defensive against a
+    -- caller accidentally passing a richer table that holds object references).
+    local outcome = entry.outcome
+    if not History.VALID_OUTCOME[outcome] then
+        outcome = History.OUTCOME_COMPLETED
+    end
+    local stored = {
+        day        = math.floor(entry.day or 0),
+        hours      = entry.hours or 0,
+        outcome    = outcome,
+        cause      = tostring(entry.cause or ""),
+        startLevel = math.floor(entry.startLevel or 1),
+        endLevel   = math.floor(entry.endLevel or 1),
+        wage       = math.floor(entry.wage or 0),
+        seq        = math.floor(entry.seq or 0),
+    }
+
+    buf[#buf + 1] = stored
+
+    -- Trim from the front until we are at/under the cap. A while-loop (not a single
+    -- remove) self-heals a buffer that was hand-edited oversized in the save file.
+    local cap = HireHallCore.HISTORY_CAP or 20
+    while #buf > cap do
+        table.remove(buf, 1)
+    end
+
+    if meta.dirtyMask ~= nil then
+        meta.dirtyMask = HireHallCore.maskSet(meta.dirtyMask, HireHallCore.DIRTY_HISTORY)
+    end
+
+    return stored
+end
+
+--- The worker's history buffer (oldest first). Always returns a table.
+function History:get(worker)
+    local meta = worker and worker.hireHallMeta
+    return (meta and meta.history) or {}
+end
+
+--- Cheap aggregate over a worker's recorded jobs — the numbers a "resume" panel or
+--- the FarmTablet would show. Pure read; allocates one small result table.
+function History:summarize(worker)
+    local result = { jobs = 0, completed = 0, dismissed = 0, failed = 0, hours = 0, wage = 0 }
+    local buf = self:get(worker)
+    for i = 1, #buf do
+        local e = buf[i]
+        result.jobs  = result.jobs + 1
+        result.hours = result.hours + (e.hours or 0)
+        result.wage  = result.wage + (e.wage or 0)
+        if e.outcome == History.OUTCOME_DISMISSED then
+            result.dismissed = result.dismissed + 1
+        elseif e.outcome == History.OUTCOME_FAILED then
+            result.failed = result.failed + 1
+        else
+            result.completed = result.completed + 1
+        end
+    end
+    return result
+end

--- a/src/hireHallCore/core/HireHallLifecycle.lua
+++ b/src/hireHallCore/core/HireHallLifecycle.lua
@@ -1,0 +1,106 @@
+-- =========================================================
+-- FS25 Realistic Worker Costs Mod
+-- =========================================================
+-- HireHallCore.core.Lifecycle — extended lifecycle state machine (FR1)
+-- =========================================================
+-- Author: TisonK
+-- =========================================================
+-- COPYRIGHT NOTICE:
+-- All rights reserved. Unauthorized redistribution, copying,
+-- or claiming this code as your own is strictly prohibited.
+-- Original author: TisonK
+-- =========================================================
+--
+-- WHAT THIS IS
+--   The persistent lifecycle state machine. Each roster worker carries a
+--   `hireHallMeta` block (lazily attached, isolated from the roster's own fields
+--   per FR0). State mutations are host-authoritative, validated against the FR1
+--   state set, zero-allocation (pre-defined string constants), mark the worker
+--   dirty, and emit a reactive event so the UI/logging never poll.
+--
+--   `available` is the ONLY state that permits field deployment — it is the logic
+--   bridge to the FR3 availability broker (per the issue's dev note).
+-- =========================================================
+
+HireHallCore = HireHallCore or {}
+HireHallCore.core = HireHallCore.core or {}
+HireHallCore.core.Lifecycle = HireHallCore.core.Lifecycle or {}
+local Lifecycle = HireHallCore.core.Lifecycle
+
+local function currentDay()
+    return (g_currentMission and g_currentMission.environment
+        and g_currentMission.environment.currentDay) or 0
+end
+
+--- Lazily attach the HireHallCore per-worker metadata block. FR0 isolation guard:
+--- only create when absent, never collide with roster/core fields. The roster's
+--- newWorker() deliberately knows nothing about this — keeping schemas separate.
+function Lifecycle:ensureMeta(worker)
+    if type(worker) ~= "table" then
+        return nil
+    end
+    if not worker.hireHallMeta then
+        worker.hireHallMeta = {
+            lifecycleState = HireHallCore.STATE.AVAILABLE,
+            history        = {},     -- reserved for FR8 circular buffer (Phase 2)
+            dirtyMask      = 0,
+            enteredDay     = currentDay(),
+            cooldownEnd    = nil,    -- in-game day when injured/onLeave auto-clears
+        }
+    end
+    return worker.hireHallMeta
+end
+
+--- Current lifecycle state string (ensures meta first; defaults to available).
+function Lifecycle:getState(worker)
+    local meta = self:ensureMeta(worker)
+    return (meta and meta.lifecycleState) or HireHallCore.STATE.AVAILABLE
+end
+
+--- Authoritative state mutation (FR1). Host-only; validates the target string;
+--- no-op when unchanged; sets the UI/HALL dirty bits; emits the lifecycle event.
+--- Returns ok(bool), reasonCodeOrNewState(string). An invalid target string trips
+--- corruption and logs the attempted path.
+function Lifecycle:transition(worker, newState, reason)
+    if not HireHallCore._isHost() then
+        return false, "NOT_HOST"
+    end
+    if HireHallCore.isCorrupted then
+        return false, "SYSTEM_ERROR"
+    end
+    if type(worker) ~= "table" then
+        return false, "INVALID_WORKER"
+    end
+    if not HireHallCore.VALID_STATE[newState] then
+        HireHallCore:fail("lifecycle.transition",
+            string.format("invalid target state '%s' for worker %s (from '%s')",
+                tostring(newState), tostring(worker.uuid),
+                tostring(worker.hireHallMeta and worker.hireHallMeta.lifecycleState)))
+        return false, "INVALID_STATE"
+    end
+
+    local meta = self:ensureMeta(worker)
+    local old = meta.lifecycleState
+    if old == newState then
+        return true, newState   -- no churn, no event
+    end
+
+    meta.lifecycleState = newState
+    meta.enteredDay     = currentDay()
+    meta.dirtyMask = HireHallCore.maskSet(meta.dirtyMask, HireHallCore.DIRTY_UI)
+    meta.dirtyMask = HireHallCore.maskSet(meta.dirtyMask, HireHallCore.DIRTY_HALL)
+
+    HireHallCore.Events:onLifecycleChanged(worker.uuid, old, newState, reason or "")
+    return true, newState
+end
+
+--- Begin an injury with a recovery cooldown N in-game days out (FR4 evolution then
+--- clears it back to available). Host-only via transition().
+function Lifecycle:setInjured(worker, recoveryDays, reason)
+    local meta = self:ensureMeta(worker)
+    if meta == nil then
+        return false, "INVALID_WORKER"
+    end
+    meta.cooldownEnd = currentDay() + math.max(1, recoveryDays or 1)
+    return self:transition(worker, HireHallCore.STATE.INJURED, reason or "injured")
+end

--- a/src/hireHallCore/integration/HireHallJobMonitor.lua
+++ b/src/hireHallCore/integration/HireHallJobMonitor.lua
@@ -1,0 +1,191 @@
+-- =========================================================
+-- FS25 Realistic Worker Costs Mod
+-- =========================================================
+-- HireHallCore.integration.JobMonitor — Internal Job Termination Monitor (FR5)
+-- =========================================================
+-- Author: TisonK
+-- =========================================================
+-- COPYRIGHT NOTICE:
+-- All rights reserved. Unauthorized redistribution, copying,
+-- or claiming this code as your own is strictly prohibited.
+-- Original author: TisonK
+-- =========================================================
+--
+-- WHAT THIS IS
+--   The "truth teller" for the Hiring Hall (FR5). It observes the end of every AI
+--   job and commits a compact result row to the worker's history buffer, so each
+--   employee accrues an accurate professional resume WITHOUT any polling and WITHOUT
+--   a second job tracker.
+--
+-- DESIGN RECONCILIATION (the FR text references engine seams that do not exist):
+--   * FR5 says "bind to WorkerManager.onWorkerEnd". There is no such method. The
+--     authoritative job-end truth — worker identity, hours, level, fatigue — is
+--     already resolved in WorkerJobTracker:_onJobStopped (the AI_JOB_STOPPED handler).
+--     So instead of re-tracking jobs, the tracker EMITS one internal signal
+--     (HireHallCore.Events "workerJobEnded") carrying those resolved facts, and this
+--     monitor SUBSCRIBES to it. That satisfies FR5's own first directive verbatim:
+--     "register a listener to the core mod's event dispatcher." One source of truth.
+--   * FR5 references "HireHallCoreHistory" for the circular buffer — that is
+--     HireHallCore.core.History here.
+--
+-- FR5 CONSTRAINTS HONORED
+--   * Event-driven only — no work in any update() loop (we are a pure subscriber).
+--   * Existence verification — roster:getWorkerExists() hard-check before any write,
+--     so a worker fired+reassigned in the same frame is never logged as an orphan.
+--   * Silent-failure policy — the write runs under HireHallCore:guard(); a failure
+--     trips isCorrupted, logs the offending seq, and fires the one System Error toast.
+--   * Host authority — the tracker only emits on the server, so this runs host-side;
+--     the synced snapshot (Phase 5) carries the buffer to clients, no MP wait here.
+--   * Growth transparency — StartRank and EndRank are both recorded when a worker is
+--     promoted mid-job.
+-- =========================================================
+
+HireHallCore = HireHallCore or {}
+HireHallCore.integration = HireHallCore.integration or {}
+HireHallCore.integration.JobMonitor = HireHallCore.integration.JobMonitor or {}
+local JobMonitor = HireHallCore.integration.JobMonitor
+
+JobMonitor._installed = false
+
+--- Subscribe to the internal job-end signal. Idempotent within a session; the
+--- subscription is dropped by HireHallCore.Events:clear() on shutdown, and re-armed
+--- on the next initialize() — so registration is deferred until the framework (and
+--- thus the roster) is live, never bound to nil references (FR5 stability rule).
+function JobMonitor:install()
+    if self._installed then
+        return
+    end
+    if HireHallCore.Events == nil then
+        return
+    end
+    HireHallCore.Events:subscribe("workerJobEnded", function(payload)
+        JobMonitor:_onJobEnded(payload)
+    end)
+    self._installed = true
+    Logging.info("[HireHallCore] Job termination monitor armed (FR5)")
+end
+
+--- Cleared on shutdown so the next mission re-subscribes against fresh listeners.
+function JobMonitor:reset()
+    self._installed = false
+end
+
+-- ---------------------------------------------------------------------------
+-- Outcome classification (engine AIMessage -> compact resume token)
+-- ---------------------------------------------------------------------------
+-- VERIFIED (FS25-Community-LUADOC, Errors/AIMessage*):
+--   * AIMessage:getType() returns AIMessageType.OK | INFO | ERROR.
+--   * AIMessageError* subclasses keep the base ERROR type  -> job failed.
+--   * AIMessageSuccessFinishedJob / SiloEmpty return OK     -> completed.
+--   * AIMessageSuccessStoppedByUser returns OK but means the player pulled the
+--     helper early -> dismissed (partial work). Distinguished via :isa().
+
+local function isStoppedByUser(aiMessage)
+    -- Global class only exists in-game; guard so logic tests / odd states degrade.
+    if AIMessageSuccessStoppedByUser == nil or aiMessage == nil then
+        return false
+    end
+    local ok, res = pcall(function()
+        return aiMessage.isa ~= nil and aiMessage:isa(AIMessageSuccessStoppedByUser)
+    end)
+    return ok and res == true
+end
+
+--- Map an aiMessage to (outcome, cause). A nil message (e.g. an internal stop)
+--- is treated as a clean completion.
+function JobMonitor:classify(aiMessage)
+    local History = HireHallCore.core.History
+    if aiMessage == nil then
+        return History.OUTCOME_COMPLETED, "finished"
+    end
+
+    local okT, msgType = pcall(function()
+        return aiMessage.getType ~= nil and aiMessage:getType() or nil
+    end)
+    if okT and AIMessageType ~= nil and msgType == AIMessageType.ERROR then
+        -- A specific numeric error code is not exposed on the base class; the ERROR
+        -- bucket is the honest, stable token we can store. (Finer codes would need
+        -- class identity the engine does not surface generically.)
+        return History.OUTCOME_FAILED, "error"
+    end
+
+    if isStoppedByUser(aiMessage) then
+        return History.OUTCOME_DISMISSED, "stoppedByUser"
+    end
+
+    return History.OUTCOME_COMPLETED, "finished"
+end
+
+-- Indicative wage cost for one job (currency). Mirrors the steady-state rate the
+-- roster snapshot advertises: base x level-efficiency x fatigue surcharge (Master
+-- immune), times hours. In per-hectare mode wage is not hours-based, so this is a
+-- best-effort estimate for the resume, not a billed figure.
+function JobMonitor:_estimateWage(hours, level, fatigue)
+    local settings = HireHallCore.settings
+    local rate = (settings and settings.getWageRate and settings:getWageRate()) or 0
+    local lf = 1.0
+    if WorkerSystem and WorkerSystem.LEVEL_WAGE_FACTOR then
+        lf = WorkerSystem.LEVEL_WAGE_FACTOR[level] or 1.0
+    end
+    local eff = rate * lf
+    local isMaster = (WorkerRoster ~= nil and level == WorkerRoster.LEVEL_MASTER)
+    if not isMaster and fatigue and fatigue > 0 and WorkerSystem then
+        eff = eff * (1 + fatigue * (WorkerSystem.FATIGUE_SURCHARGE or 0))
+    end
+    return eff * math.max(0, hours or 0)
+end
+
+-- ---------------------------------------------------------------------------
+-- The subscriber (host-only; the tracker only emits on the server)
+-- ---------------------------------------------------------------------------
+function JobMonitor:_onJobEnded(payload)
+    if type(payload) ~= "table" then
+        return
+    end
+    if HireHallCore.isCorrupted then
+        return   -- subsystem halted for the session
+    end
+
+    local roster = HireHallCore.roster
+    if roster == nil then
+        return
+    end
+
+    -- FR5 existence verification: never process an orphan deleted from the roster in
+    -- the same frame it terminated.
+    local workerId = payload.workerUuid
+    local exists = false
+    if roster.getWorkerExists ~= nil then
+        exists = roster:getWorkerExists(workerId)
+    else
+        exists = roster:getWorker(workerId) ~= nil
+    end
+    if not exists then
+        return
+    end
+
+    local worker = roster:getWorker(workerId)
+    local outcome, cause = self:classify(payload.aiMessage)
+    local startLevel = payload.startLevel or (worker.level or 1)
+    local endLevel   = worker.level or startLevel
+    local fatigue    = payload.fatigue or worker.fatigue or 0
+    local wage       = self:_estimateWage(payload.hours, endLevel, fatigue)
+    local day = (g_currentMission and g_currentMission.environment
+        and g_currentMission.environment.currentDay) or 0
+
+    -- FR5 silent-failure policy: the write is the sensitive op. guard() pcalls it and,
+    -- on failure, trips the one corruption flag + single System Error toast and logs
+    -- the offending seq so the bad job is identifiable.
+    HireHallCore:guard(string.format("jobMonitor.record(seq=%s)", tostring(payload.seq)), function()
+        HireHallCore.core.History:record(worker, {
+            day        = day,
+            hours      = payload.hours or 0,
+            outcome    = outcome,
+            cause      = cause,
+            startLevel = startLevel,
+            endLevel   = endLevel,
+            wage       = wage,
+            seq        = payload.seq or 0,
+        })
+    end)
+end

--- a/src/hireHallCore/integration/HireHallProStaff.lua
+++ b/src/hireHallCore/integration/HireHallProStaff.lua
@@ -1,0 +1,70 @@
+-- =========================================================
+-- FS25 Realistic Worker Costs Mod
+-- =========================================================
+-- HireHallCore.integration.ProStaff — safe internal telemetry accessor (FR2)
+-- =========================================================
+-- Author: TisonK
+-- =========================================================
+-- COPYRIGHT NOTICE:
+-- All rights reserved. Unauthorized redistribution, copying,
+-- or claiming this code as your own is strictly prohibited.
+-- Original author: TisonK
+-- =========================================================
+--
+-- WHAT THIS IS
+--   The single, type-guarded boundary through which HireHallCore reads Pro-Staff
+--   indicators (fatigue, XP, level). HireHallCore is a READ-ONLY consumer of this
+--   data (FR0 boundary) — it never writes these fields.
+--
+--   In this mod the "Pro-Staff" telemetry lives directly on the roster worker
+--   record (worker.fatigue is 0..1, worker.totalXP, worker.level), NOT under a
+--   worker.proStaff.* namespace as the FR text assumes. This accessor is exactly
+--   the indirection FR2 asks for: if that schema ever changes, only this file
+--   updates, and every read degrades to a SAFE DEFAULT instead of crashing the
+--   broker (FR3 schema-drift rule: a failed telemetry read must never lock the
+--   workforce).
+-- =========================================================
+
+HireHallCore = HireHallCore or {}
+HireHallCore.integration = HireHallCore.integration or {}
+HireHallCore.integration.ProStaff = HireHallCore.integration.ProStaff or {}
+local ProStaff = HireHallCore.integration.ProStaff
+
+local function num(v, default)
+    if type(v) == "number" then
+        return v
+    end
+    return default
+end
+
+--- Fatigue as a 0..100 percentage. The roster stores 0..1; we normalize so broker
+--- code reads like the spec ("getFatigue(worker) < 95"). Safe default 0 (rested).
+function ProStaff:getFatigue(worker)
+    if type(worker) ~= "table" then
+        return 0
+    end
+    return num(worker.fatigue, 0) * 100
+end
+
+--- Total accrued XP. Safe default 0.
+function ProStaff:getXP(worker)
+    if type(worker) ~= "table" then
+        return 0
+    end
+    return num(worker.totalXP, 0)
+end
+
+--- Level tier (1 Novice / 2 Experienced / 3 Master). Safe default 1.
+function ProStaff:getLevel(worker)
+    if type(worker) ~= "table" then
+        return 1
+    end
+    return num(worker.level, 1)
+end
+
+--- True when the telemetry looks structurally valid. The broker/evolution engine
+--- use this to apply the FR3 "treat as available on drift" rule rather than
+--- trusting a coerced default.
+function ProStaff:isReadable(worker)
+    return type(worker) == "table" and type(worker.fatigue) == "number"
+end

--- a/src/hireHallCore/xml/HireHallSchema.lua
+++ b/src/hireHallCore/xml/HireHallSchema.lua
@@ -1,0 +1,129 @@
+-- =========================================================
+-- FS25 Realistic Worker Costs Mod
+-- =========================================================
+-- HireHallCore.Schema — versioned save persistence & migration (FR0 / FR14)
+-- =========================================================
+-- Author: TisonK
+-- =========================================================
+-- COPYRIGHT NOTICE:
+-- All rights reserved. Unauthorized redistribution, copying,
+-- or claiming this code as your own is strictly prohibited.
+-- Original author: TisonK
+-- =========================================================
+--
+-- WHAT THIS IS
+--   All HireHallCore persistent state, segregated into its OWN savegame file
+--   (hireHallCore.xml) under a <hireHallCore version="1"> root with a
+--   <hireHallCoreGlobal> block. A separate file is the strongest form of the FR14
+--   "schema isolation / prevent file corruption" directive: a bad HireHallCore
+--   write can never damage the roster's workerData.xml.
+--
+--   Per-worker rows are keyed by the roster's stable uuid, so on load we re-attach
+--   lifecycle state onto the matching roster worker. Workers no longer on the
+--   roster are skipped. Mirrors the proven XMLFile.create / iterate / delete
+--   pattern used by WorkerRoster (no new API surface).
+-- =========================================================
+
+HireHallCore = HireHallCore or {}
+HireHallCore.Schema = HireHallCore.Schema or {}
+local Schema = HireHallCore.Schema
+
+Schema.SAVE_FILE = "hireHallCore.xml"
+Schema.ROOT      = "hireHallCore"
+
+--- Write lifecycle state for every worker that has a meta block.
+function Schema:save(missionInfo, roster)
+    local dir = missionInfo and missionInfo.savegameDirectory
+    if not dir or roster == nil then
+        return false
+    end
+
+    local path = dir .. "/" .. Schema.SAVE_FILE
+    local xmlFile = XMLFile.create("wc_HireHallCoreXML", path, Schema.ROOT)
+    if xmlFile == nil then
+        Logging.warning("[HireHallCore] Failed to create save file: " .. path)
+        return false
+    end
+
+    local root = Schema.ROOT
+    xmlFile:setInt(root .. "#version", HireHallCore.SCHEMA_VERSION)
+    -- Protected global block (FR0 <hireHallCoreGlobal>) — reserved for hall-level
+    -- state (recruitment seed, rotation clock) added in Phase 3 (FR9/FR10).
+    xmlFile:setInt(root .. ".hireHallCoreGlobal#schemaVersion", HireHallCore.SCHEMA_VERSION)
+
+    local i = 0
+    for _, w in ipairs(roster:getAll()) do
+        local meta = w.hireHallMeta
+        if meta then
+            local key = string.format("%s.worker(%d)", root, i)
+            xmlFile:setInt(key .. "#uuid", w.uuid)
+            xmlFile:setString(key .. "#lifecycleState",
+                meta.lifecycleState or HireHallCore.STATE.AVAILABLE)
+            xmlFile:setInt(key .. "#enteredDay", meta.enteredDay or 0)
+            if meta.cooldownEnd ~= nil then
+                xmlFile:setInt(key .. "#cooldownEnd", meta.cooldownEnd)
+            end
+            i = i + 1
+        end
+    end
+
+    xmlFile:save()
+    xmlFile:delete()
+    Logging.info("[HireHallCore] Saved lifecycle state (%d workers) -> %s", i, path)
+    return true
+end
+
+--- Read lifecycle state back and re-attach it to roster workers by uuid.
+function Schema:loadIfExists(missionInfo, roster)
+    local dir = missionInfo and missionInfo.savegameDirectory
+    if not dir or roster == nil then
+        return false
+    end
+
+    local path = dir .. "/" .. Schema.SAVE_FILE
+    local xmlFile = XMLFile.loadIfExists("wc_HireHallCoreXML", path, Schema.ROOT)
+    if xmlFile == nil then
+        Logging.info("[HireHallCore] No save found (new/first run) — lifecycle defaults to available")
+        return false
+    end
+
+    local root = Schema.ROOT
+    local version = xmlFile:getInt(root .. "#version", 1)
+    version = Schema:migrateLegacy(version)
+
+    local applied = 0
+    xmlFile:iterate(root .. ".worker", function(_, key)
+        local uuid = xmlFile:getInt(key .. "#uuid")
+        if uuid == nil then
+            return
+        end
+        local w = roster:getWorker(uuid)
+        if w == nil then
+            return   -- worker no longer on the roster; drop the stale row
+        end
+        local meta = HireHallCore.core.Lifecycle:ensureMeta(w)
+        local state = xmlFile:getString(key .. "#lifecycleState", HireHallCore.STATE.AVAILABLE)
+        if HireHallCore.VALID_STATE[state] then
+            meta.lifecycleState = state
+        end
+        meta.enteredDay  = xmlFile:getInt(key .. "#enteredDay", meta.enteredDay or 0)
+        meta.cooldownEnd = xmlFile:getInt(key .. "#cooldownEnd", nil)
+        applied = applied + 1
+    end)
+
+    xmlFile:delete()
+    Logging.info("[HireHallCore] Loaded lifecycle state (%d workers, schema v%d)", applied, version)
+    return true
+end
+
+--- FR0 / FR14 — iterative forward migration. Each loop turn upgrades one schema
+--- version until current. No-op today (v1 is current); the loop is in place so a
+--- future v2 just adds `if version == 1 then ...transform... end`.
+function Schema:migrateLegacy(version)
+    local v = version or 1
+    while v < HireHallCore.SCHEMA_VERSION do
+        -- if v == 1 then ... migrate v1 -> v2 ... end
+        v = v + 1
+    end
+    return v
+end

--- a/src/hireHallCore/xml/HireHallSchema.lua
+++ b/src/hireHallCore/xml/HireHallSchema.lua
@@ -63,6 +63,25 @@ function Schema:save(missionInfo, roster)
             if meta.cooldownEnd ~= nil then
                 xmlFile:setInt(key .. "#cooldownEnd", meta.cooldownEnd)
             end
+
+            -- FR5 (#66): persist the job-history circular buffer (schema v2). Rows are
+            -- numbers/strings only, already capped to HISTORY_CAP at write time.
+            local hist = meta.history
+            if type(hist) == "table" then
+                for j = 1, #hist do
+                    local e = hist[j]
+                    local hk = string.format("%s.h(%d)", key, j - 1)
+                    xmlFile:setInt(hk .. "#day",        e.day or 0)
+                    xmlFile:setFloat(hk .. "#hours",    e.hours or 0)
+                    xmlFile:setString(hk .. "#outcome", e.outcome or "completed")
+                    xmlFile:setString(hk .. "#cause",   e.cause or "")
+                    xmlFile:setInt(hk .. "#startLevel", e.startLevel or 1)
+                    xmlFile:setInt(hk .. "#endLevel",   e.endLevel or 1)
+                    xmlFile:setInt(hk .. "#wage",       e.wage or 0)
+                    xmlFile:setInt(hk .. "#seq",        e.seq or 0)
+                end
+            end
+
             i = i + 1
         end
     end
@@ -108,6 +127,27 @@ function Schema:loadIfExists(missionInfo, roster)
         end
         meta.enteredDay  = xmlFile:getInt(key .. "#enteredDay", meta.enteredDay or 0)
         meta.cooldownEnd = xmlFile:getInt(key .. "#cooldownEnd", nil)
+
+        -- FR5 (#66): restore the job-history buffer (schema v2; absent in v1 saves,
+        -- which simply load an empty resume). Already capped on write, but the cap is
+        -- re-applied defensively on the next record().
+        local hist = {}
+        xmlFile:iterate(key .. ".h", function(_, hk)
+            hist[#hist + 1] = {
+                day        = xmlFile:getInt(hk .. "#day", 0),
+                hours      = xmlFile:getFloat(hk .. "#hours", 0),
+                outcome    = xmlFile:getString(hk .. "#outcome", "completed"),
+                cause      = xmlFile:getString(hk .. "#cause", ""),
+                startLevel = xmlFile:getInt(hk .. "#startLevel", 1),
+                endLevel   = xmlFile:getInt(hk .. "#endLevel", 1),
+                wage       = xmlFile:getInt(hk .. "#wage", 0),
+                seq        = xmlFile:getInt(hk .. "#seq", 0),
+            }
+        end)
+        if #hist > 0 then
+            meta.history = hist
+        end
+
         applied = applied + 1
     end)
 
@@ -117,12 +157,12 @@ function Schema:loadIfExists(missionInfo, roster)
 end
 
 --- FR0 / FR14 — iterative forward migration. Each loop turn upgrades one schema
---- version until current. No-op today (v1 is current); the loop is in place so a
---- future v2 just adds `if version == 1 then ...transform... end`.
+--- version until current. v1 -> v2 is additive (per-worker history, #66): a v1 save
+--- simply has no <h> rows and loads an empty resume, so no transform is required.
 function Schema:migrateLegacy(version)
     local v = version or 1
     while v < HireHallCore.SCHEMA_VERSION do
-        -- if v == 1 then ... migrate v1 -> v2 ... end
+        -- if v == 1 then ... (v1 -> v2: history is additive, nothing to transform) end
         v = v + 1
     end
     return v

--- a/src/main.lua
+++ b/src/main.lua
@@ -31,6 +31,18 @@ source(modDirectory .. "src/settings/WorkerSettingsUI.lua")
 source(modDirectory .. "src/WorkerRoster.lua")
 source(modDirectory .. "src/WorkerSystem.lua")
 source(modDirectory .. "src/WorkerJobTracker.lua")
+
+-- HireHallCore framework (FR0-FR4, Phase 1). Foundation first (defines the global
+-- namespace + constants), then the modules that attach to it. Loaded before
+-- WorkerManager, which wires it via HireHallCore:setup().
+source(modDirectory .. "src/hireHallCore/HireHallCore.lua")
+source(modDirectory .. "src/hireHallCore/core/HireHallEvents.lua")
+source(modDirectory .. "src/hireHallCore/integration/HireHallProStaff.lua")
+source(modDirectory .. "src/hireHallCore/core/HireHallLifecycle.lua")
+source(modDirectory .. "src/hireHallCore/core/HireHallEvolution.lua")
+source(modDirectory .. "src/hireHallCore/core/HireHallAPI.lua")
+source(modDirectory .. "src/hireHallCore/xml/HireHallSchema.lua")
+
 source(modDirectory .. "src/gui/WCRosterPanel.lua") -- created in WorkerManager.new, so load before it
 source(modDirectory .. "src/WorkerManager.lua")
 source(modDirectory .. "src/WCNetworkEvents.lua")   -- Pro-Staff Phase 5: MP roster sync + command events

--- a/src/main.lua
+++ b/src/main.lua
@@ -39,8 +39,10 @@ source(modDirectory .. "src/hireHallCore/HireHallCore.lua")
 source(modDirectory .. "src/hireHallCore/core/HireHallEvents.lua")
 source(modDirectory .. "src/hireHallCore/integration/HireHallProStaff.lua")
 source(modDirectory .. "src/hireHallCore/core/HireHallLifecycle.lua")
+source(modDirectory .. "src/hireHallCore/core/HireHallHistory.lua")     -- FR5 (#66): job-history circular buffer (uses Lifecycle:ensureMeta)
 source(modDirectory .. "src/hireHallCore/core/HireHallEvolution.lua")
 source(modDirectory .. "src/hireHallCore/core/HireHallAPI.lua")
+source(modDirectory .. "src/hireHallCore/integration/HireHallJobMonitor.lua") -- FR5 (#66): Internal Job Termination Monitor (subscribes to workerJobEnded)
 source(modDirectory .. "src/hireHallCore/xml/HireHallSchema.lua")
 
 source(modDirectory .. "src/gui/WCRosterPanel.lua") -- created in WorkerManager.new, so load before it
@@ -216,4 +218,4 @@ end
 getfenv(0)["workerCosts"]       = workerCosts
 getfenv(0)["workerCostsStatus"] = workerCostsStatus
 
-Logging.info("[Worker Costs] v2.0.0.0 loaded — type 'workerCosts' in console for help")
+Logging.info("[Worker Costs] v2.2.0.0 loaded — type 'workerCosts' in console for help")

--- a/src/settings/WorkerSettingsGUI.lua
+++ b/src/settings/WorkerSettingsGUI.lua
@@ -36,6 +36,7 @@ function WorkerSettingsGUI:registerConsoleCommands()
     
     addConsoleCommand("WorkerCostsShowSettings", "Show current settings", "consoleCommandShowSettings", self)
     addConsoleCommand("WorkerCostsShowRoster", "Show the Pro-Staff worker roster (id, name, level, hours, jobs, XP)", "consoleCommandShowRoster", self)
+    addConsoleCommand("WorkerCostsHallState", "Show each worker's HireHallCore lifecycle state + dispatch availability", "consoleCommandHallState", self)
     addConsoleCommand("WorkerCostsRoster", "Open/close the clickable roster panel (hire/fire/assign)", "consoleCommandRosterPanel", self)
     addConsoleCommand("WorkerCostsGrantXP", "TESTING: add XP (=hours) to all roster workers; recomputes level (Experienced=40, Master=160)", "consoleCommandGrantXP", self)
     addConsoleCommand("WorkerCostsHire", "Hire a worker by name (Pro-Staff)", "consoleCommandHire", self)
@@ -242,6 +243,45 @@ function WorkerSettingsGUI:consoleCommandShowRoster()
                 w.totalHours or 0, w.totalJobs or 0, w.totalXP or 0,
                 math.floor((w.fatigue or 0) * 100),
                 status
+            ))
+        end
+    end
+    table.insert(lines, "==========================")
+
+    local out = table.concat(lines, "\n")
+    print(out)
+    return out
+end
+
+-- HireHallCore (Phase 1) has no UI until Phase 4, so this is how you SEE it working:
+-- per-worker lifecycle state plus the availability broker's verdict + reason code.
+function WorkerSettingsGUI:consoleCommandHallState()
+    if g_WorkerManager == nil or g_WorkerManager.workerRoster == nil then
+        return "Error: Worker Costs Mod not initialized"
+    end
+    if HireHallCore == nil then
+        return "Error: HireHallCore not loaded"
+    end
+
+    local roster = g_WorkerManager.workerRoster
+    local workers = roster:getAll()
+    local lines = { string.format("=== HireHallCore Lifecycle (%d) %s===",
+        #workers, HireHallCore.isCorrupted and "[CORRUPTED] " or "") }
+
+    if not HireHallCore._isHost() then
+        table.insert(lines, "(client — lifecycle is host-authoritative; run this on the host)")
+    elseif #workers == 0 then
+        table.insert(lines, "(empty — start an AI helper to auto-hire one)")
+    else
+        local API = HireHallCore.core.API
+        for _, w in ipairs(workers) do
+            local state = HireHallCore.core.Lifecycle:getState(w)
+            local available, reason = API:isWorkerAvailable(w.uuid)
+            table.insert(lines, string.format(
+                "#%d  %-16s  state=%-10s  fatigue=%d%%  dispatch=%s (%s)",
+                w.uuid, w.name or "Worker", state,
+                math.floor((w.fatigue or 0) * 100),
+                available and "YES" or "no", reason
             ))
         end
     end


### PR DESCRIPTION
Brings the HireHallCore framework and the new Hiring Hall features from development to main. Bumps the mod to v2.2.0.0.

## New player facing features
- Daily hiring limit (#69): hire at most 5 workers per in game day. The counter resets at the start of the next day, survives a save and reload so it cannot be bypassed, and you get a clear notice plus a panel counter when you hit the cap.
- Trusted employees (#67): star a worker in the Pro-Staff Panel to keep them pinned at the top of the list, with a highlighted row. Saved and synced to everyone in multiplayer.
- Earned mastery (#68): Master workers no longer turn up in the recruitment pool. Master is now reached only by working and gaining XP, and Experienced recruits unlock as your staff put in the hours.
- Job history (#66): every worker keeps a short resume of recent jobs (completed, dismissed, or failed, with hours and a cost estimate), recorded the moment a job ends and persisted in its own save file.

## Framework (backend, already on development)
- HireHallCore Phase 1 (#62 #63 #64 #65): lifecycle state machine, compound availability broker, time sliced evolution engine, and the engineering controls they sit on. Server authoritative and isolated in its own save file.

## Notes
- All worker data and the new state persist across save and reload. Old saves load cleanly: job history defaults empty and the daily cap starts fresh.
- Verified offline (parse plus logic tests) and tested in game.
- Issues are left open on purpose and carry the landed label for tracking, so this PR does not auto close them.