### PR TITLE
Release 2.2.1.0 + sync main (Pro-Staff work catch-up)

### DIFF
--- a/modDesc.xml
+++ b/modDesc.xml
@@ -531,32 +531,32 @@
             <da>Mod-status</da>
         </text>
         <text name="wc_label_cost_mode">
-            <en>Cost Mode:</en>
-        
-            <de>[EN] Cost Mode:</de>
-            <fr>[EN] Cost Mode:</fr>
-            <pl>[EN] Cost Mode:</pl>
-            <es>[EN] Cost Mode:</es>
-            <it>[EN] Cost Mode:</it>
-            <cz>[EN] Cost Mode:</cz>
-            <br>[EN] Cost Mode:</br>
-            <uk>[EN] Cost Mode:</uk>
-            <ru>[EN] Cost Mode:</ru>
-            <da>Omkostningstilstand</da>
+            <en>Payment Strategy:</en>
+
+            <de>[EN] Payment Strategy:</de>
+            <fr>[EN] Payment Strategy:</fr>
+            <pl>[EN] Payment Strategy:</pl>
+            <es>[EN] Payment Strategy:</es>
+            <it>[EN] Payment Strategy:</it>
+            <cz>[EN] Payment Strategy:</cz>
+            <br>[EN] Payment Strategy:</br>
+            <uk>[EN] Payment Strategy:</uk>
+            <ru>[EN] Payment Strategy:</ru>
+            <da>[EN] Payment Strategy:</da>
         </text>
         <text name="wc_label_wage_level">
-            <en>Wage Level:</en>
-        
-            <de>[EN] Wage Level:</de>
-            <fr>[EN] Wage Level:</fr>
-            <pl>[EN] Wage Level:</pl>
-            <es>[EN] Wage Level:</es>
-            <it>[EN] Wage Level:</it>
-            <cz>[EN] Wage Level:</cz>
-            <br>[EN] Wage Level:</br>
-            <uk>[EN] Wage Level:</uk>
-            <ru>[EN] Wage Level:</ru>
-            <da>Løn Niveau</da>
+            <en>Compensation Tier:</en>
+
+            <de>[EN] Compensation Tier:</de>
+            <fr>[EN] Compensation Tier:</fr>
+            <pl>[EN] Compensation Tier:</pl>
+            <es>[EN] Compensation Tier:</es>
+            <it>[EN] Compensation Tier:</it>
+            <cz>[EN] Compensation Tier:</cz>
+            <br>[EN] Compensation Tier:</br>
+            <uk>[EN] Compensation Tier:</uk>
+            <ru>[EN] Compensation Tier:</ru>
+            <da>[EN] Compensation Tier:</da>
         </text>
         <text name="wc_label_current_rate">
             <en>Current Rate:</en>

--- a/modDesc.xml
+++ b/modDesc.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" standalone="no" ?>
 <modDesc descVersion="92">
     <author>TisonK</author>
-    <version>2.2.0.0</version>
+    <version>2.2.1.0</version>
     <modName>FS25_WorkerCostsMod</modName>
     <title>
         <en>Realistic Worker Costs</en>

--- a/src/gui/WCRosterPanel.lua
+++ b/src/gui/WCRosterPanel.lua
@@ -144,6 +144,12 @@ end
 -- ── Visibility ────────────────────────────────────────────
 function WCRosterPanel:open()
     if not self.initialized then self:initialize() end
+    -- #84 Don't open underneath the Farm Tablet — they are mutually-exclusive
+    -- overlays. The player closes the tablet first (focus API; absent = nil = allow).
+    local ft = g_currentMission and g_currentMission.farmTablet
+    if ft and ft.isVisible then
+        return
+    end
     self.isVisible = true
     self.page      = 0
     self.infoMsg   = nil
@@ -176,6 +182,14 @@ function WCRosterPanel:update()
     end
     -- Auto-close if a real GUI (menu/dialog) opens on top.
     if g_gui and (g_gui:getIsGuiVisible() or g_gui:getIsDialogVisible()) then
+        self:close()
+        return
+    end
+    -- #84 The Farm Tablet is a custom overlay g_gui cannot see, so use its focus API
+    -- (g_currentMission.farmTablet) to step aside when the tablet is showing — two
+    -- full-screen overlays must never fight. No-ops cleanly when FarmTablet is absent.
+    local ft = g_currentMission and g_currentMission.farmTablet
+    if ft and ft.isVisible then
         self:close()
     end
 end

--- a/src/gui/WCWageSettingsFrame.lua
+++ b/src/gui/WCWageSettingsFrame.lua
@@ -48,6 +48,7 @@ function WCWageSettingsFrame:bindCallbacks()
                 g_WorkerManager.settings:save()
                 self:refreshRatePreview()
                 self:refreshHelpText()
+                self:refreshWageLevelOptions()   -- #83 re-unit the tier labels for the new strategy
             end
         end
     end
@@ -128,18 +129,8 @@ function WCWageSettingsFrame:refresh()
         end
     end
 
-    if self.optWageLevel then
-        if self.optWageLevel.setTexts then
-            self.optWageLevel:setTexts({
-                g_i18n:getText("wc_diff_1"),
-                g_i18n:getText("wc_diff_2"),
-                g_i18n:getText("wc_diff_3"),
-            })
-        end
-        if self.optWageLevel.setState then
-            self.optWageLevel:setState(settings.wageLevel)
-        end
-    end
+    -- #83 Wage-level (Compensation Tier) labels are built with a mode-aware unit.
+    self:refreshWageLevelOptions()
 
     if self.optNotifications and self.optNotifications.setState then
         self.optNotifications:setState(settings.showNotifications and 2 or 1)
@@ -157,6 +148,34 @@ function WCWageSettingsFrame:refresh()
 
     self:refreshRatePreview()
     self:refreshHelpText()
+end
+
+-- #83 Build the Compensation Tier option labels with a unit that tracks the active
+-- Payment Strategy ($/h vs $/ha). The localized tier name is kept (the "(rate)" part
+-- is stripped and rebuilt), and the unit matches the English format the big rate
+-- display already uses — so the option no longer shows "/h" while in Per-Hectare mode.
+function WCWageSettingsFrame:refreshWageLevelOptions()
+    if self.optWageLevel == nil or self.optWageLevel.setTexts == nil then return end
+    local settings = g_WorkerManager and g_WorkerManager.settings
+    if settings == nil then return end
+
+    local unit  = (settings.costMode == Settings.COST_MODE_PER_HECTARE) and "ha" or "h"
+    local rates = { 15, 25, 40 }   -- Settings:getWageRate() per level (Low / Medium / High)
+    local texts = {}
+    for i = 1, 3 do
+        local base = g_i18n:getText("wc_diff_" .. i) or ""
+        local name = base:gsub("%s*%b()%s*$", "")   -- drop "($15/h)", keep the localized tier name
+        texts[i] = string.format("%s ($%d/%s)", name, rates[i], unit)
+    end
+
+    -- Guard so setState() doesn't re-fire the wage-level callback mid-update.
+    local wasRefreshing = self._refreshing
+    self._refreshing = true
+    self.optWageLevel:setTexts(texts)
+    if self.optWageLevel.setState then
+        self.optWageLevel:setState(settings.wageLevel)
+    end
+    self._refreshing = wasRefreshing
 end
 
 -- Update the live "effective rate" preview text

--- a/src/hireHallCore/core/HireHallEvolution.lua
+++ b/src/hireHallCore/core/HireHallEvolution.lua
@@ -33,8 +33,9 @@ HireHallCore.core.Evolution = HireHallCore.core.Evolution or {
 local Evolution = HireHallCore.core.Evolution
 
 --- Push a workerId to the front-of-line (FR4 urgent queue). Used when a worker is
---- being viewed in the FarmTablet (EdgeTabContext; Phase 4) so the UI always sees
---- fresh state. Small set, deduped in place — no allocation churn.
+--- being viewed in the FarmTablet personnel app so the UI always sees fresh state
+--- (the tablet's active app is known via the #84 focus API). Small set, deduped in
+--- place — no allocation churn.
 function Evolution:pushUrgent(workerId)
     if workerId == nil then
         return

--- a/src/main.lua
+++ b/src/main.lua
@@ -218,4 +218,4 @@ end
 getfenv(0)["workerCosts"]       = workerCosts
 getfenv(0)["workerCostsStatus"] = workerCostsStatus
 
-Logging.info("[Worker Costs] v2.2.0.0 loaded — type 'workerCosts' in console for help")
+Logging.info("[Worker Costs] v2.2.1.0 loaded — type 'workerCosts' in console for help")

--- a/xml/gui/WCDashboardFrame.xml
+++ b/xml/gui/WCDashboardFrame.xml
@@ -21,20 +21,20 @@
                     <ThreePartBitmap profile="fs25_lineSeparatorTop" position="5px -34px" width="280px"/>
 
                     <!-- Rows individually positioned — no ColBoxV wrapper -->
-                    <BoxLayout profile="WC_RowBoxH" position="5px -52px" width="290px">
-                        <Text profile="WC_RowLabel" text="$l10n_wc_label_mod_enabled" width="130px"/>
+                    <BoxLayout profile="WC_RowBoxH" position="5px -52px" width="330px">
+                        <Text profile="WC_RowLabel" text="$l10n_wc_label_mod_enabled" width="170px"/>
                         <Text profile="WC_RowValue" id="txtModEnabled" width="150px"/>
                     </BoxLayout>
-                    <BoxLayout profile="WC_RowBoxH" position="5px -80px" width="290px">
-                        <Text profile="WC_RowLabel" text="$l10n_wc_label_cost_mode" width="130px"/>
+                    <BoxLayout profile="WC_RowBoxH" position="5px -80px" width="330px">
+                        <Text profile="WC_RowLabel" text="$l10n_wc_label_cost_mode" width="170px"/>
                         <Text profile="WC_RowValue" id="txtCostMode" width="150px"/>
                     </BoxLayout>
-                    <BoxLayout profile="WC_RowBoxH" position="5px -108px" width="290px">
-                        <Text profile="WC_RowLabel" text="$l10n_wc_label_wage_level" width="130px"/>
+                    <BoxLayout profile="WC_RowBoxH" position="5px -108px" width="330px">
+                        <Text profile="WC_RowLabel" text="$l10n_wc_label_wage_level" width="170px"/>
                         <Text profile="WC_RowValue" id="txtWageLevel" width="150px"/>
                     </BoxLayout>
-                    <BoxLayout profile="WC_RowBoxH" position="5px -136px" width="290px">
-                        <Text profile="WC_RowLabel" text="$l10n_wc_label_current_rate" width="130px"/>
+                    <BoxLayout profile="WC_RowBoxH" position="5px -136px" width="330px">
+                        <Text profile="WC_RowLabel" text="$l10n_wc_label_current_rate" width="170px"/>
                         <Text profile="WC_RowValueGreen" id="txtCurrentRate" width="150px"/>
                     </BoxLayout>
 

--- a/xml/gui/WCWageSettingsFrame.xml
+++ b/xml/gui/WCWageSettingsFrame.xml
@@ -64,9 +64,10 @@
                 <Text profile="WC_SectionTitle" position="0px -10px" text="$l10n_wc_section_effective"/>
                 <ThreePartBitmap profile="fs25_lineSeparatorTop" position="0px -34px" width="400px"/>
 
-                <Text profile="WC_BigStatLabel" position="0px -58px" text="$l10n_wc_label_effective_rate"/>
-                <Text profile="WC_BigStat" id="txtBigRate" position="0px -78px"/>
-                <Text profile="WC_BigStatLabel" id="txtRateLabel" position="0px -124px"/>
+                <!-- #82 Redundant "Effective Rate" label removed; the section title above
+                     already names this. Big stat shifts up under the separator. -->
+                <Text profile="WC_BigStat" id="txtBigRate" position="0px -58px"/>
+                <Text profile="WC_BigStatLabel" id="txtRateLabel" position="0px -104px"/>
 
                 <ThreePartBitmap profile="fs25_lineSeparatorTop" position="0px -152px" width="400px"/>
 


### PR DESCRIPTION
Brings main up to the current Pro-Staff line and the 2.2.1.0 bump. main had no unique content (its lead was merge bubbles; the traffic-stats workflow is already in development), so this is a clean catch-up.