### PR TITLE
2.2.2.0 — readable WCAboutFrame sections + two-column Pro-Staff (#80)

### DIFF
--- a/modDesc.xml
+++ b/modDesc.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" standalone="no" ?>
 <modDesc descVersion="92">
     <author>TisonK</author>
-    <version>2.2.1.0</version>
+    <version>2.2.2.0</version>
     <modName>FS25_WorkerCostsMod</modName>
     <title>
         <en>Realistic Worker Costs</en>

--- a/modDesc.xml
+++ b/modDesc.xml
@@ -933,70 +933,175 @@
             <da>[EN] Per Hectare</da>
         </text>
 
-        <!-- #80: per-tab body content -->
-        <text name="wc_about_core_body">
-            <en>Realistic Worker Costs replaces the default pay system with a billing model based on real time.
-
-Each active AI worker is charged on a fixed schedule, no matter the game speed. Deductions happen quietly in the background every payment interval.
-
-REAL-TIME BILLING
-Tying wages to real minutes keeps costs predictable at any time scale. Fast-forwarding a season no longer drains your account.
-
-SAVE PERSISTENCE
-Cost mode, wage level and notification settings are saved per save game and restored on load. Multiplayer clients stay in sync with the host.</en>
-            <de>[EN] Realistic Worker Costs replaces the default pay system with a billing model based on real time. Each active AI worker is charged on a fixed schedule, no matter the game speed.</de>
-            <fr>[EN] Realistic Worker Costs replaces the default pay system with a billing model based on real time. Each active AI worker is charged on a fixed schedule, no matter the game speed.</fr>
-            <es>[EN] Realistic Worker Costs replaces the default pay system with a billing model based on real time. Each active AI worker is charged on a fixed schedule, no matter the game speed.</es>
-            <pl>[EN] Realistic Worker Costs replaces the default pay system with a billing model based on real time. Each active AI worker is charged on a fixed schedule, no matter the game speed.</pl>
-            <it>[EN] Realistic Worker Costs replaces the default pay system with a billing model based on real time. Each active AI worker is charged on a fixed schedule, no matter the game speed.</it>
-            <cz>[EN] Realistic Worker Costs replaces the default pay system with a billing model based on real time. Each active AI worker is charged on a fixed schedule, no matter the game speed.</cz>
-            <br>[EN] Realistic Worker Costs replaces the default pay system with a billing model based on real time. Each active AI worker is charged on a fixed schedule, no matter the game speed.</br>
-            <uk>[EN] Realistic Worker Costs replaces the default pay system with a billing model based on real time. Each active AI worker is charged on a fixed schedule, no matter the game speed.</uk>
-            <ru>[EN] Realistic Worker Costs replaces the default pay system with a billing model based on real time. Each active AI worker is charged on a fixed schedule, no matter the game speed.</ru>
-            <da>[EN] Realistic Worker Costs replaces the default pay system with a billing model based on real time. Each active AI worker is charged on a fixed schedule, no matter the game speed.</da>
+        <!-- #80: per-tab sectioned content (headers + short bodies; English-first, [EN] stubs) -->
+        <text name="wc_about_core_intro">
+            <en>Realistic Worker Costs replaces the default pay system with a billing model based on real time. Each active AI worker is charged on a fixed schedule, no matter the game speed, with deductions happening quietly every payment interval. Tying wages to real minutes keeps your costs predictable whether you play at 1x or 120x.</en>
+            <de>[EN] Replaces the default pay with real-time billing. Each active AI worker is charged on a fixed schedule regardless of game speed.</de>
+            <fr>[EN] Replaces the default pay with real-time billing. Each active AI worker is charged on a fixed schedule regardless of game speed.</fr>
+            <es>[EN] Replaces the default pay with real-time billing. Each active AI worker is charged on a fixed schedule regardless of game speed.</es>
+            <pl>[EN] Replaces the default pay with real-time billing. Each active AI worker is charged on a fixed schedule regardless of game speed.</pl>
+            <it>[EN] Replaces the default pay with real-time billing. Each active AI worker is charged on a fixed schedule regardless of game speed.</it>
+            <cz>[EN] Replaces the default pay with real-time billing. Each active AI worker is charged on a fixed schedule regardless of game speed.</cz>
+            <br>[EN] Replaces the default pay with real-time billing. Each active AI worker is charged on a fixed schedule regardless of game speed.</br>
+            <uk>[EN] Replaces the default pay with real-time billing. Each active AI worker is charged on a fixed schedule regardless of game speed.</uk>
+            <ru>[EN] Replaces the default pay with real-time billing. Each active AI worker is charged on a fixed schedule regardless of game speed.</ru>
+            <da>[EN] Replaces the default pay with real-time billing. Each active AI worker is charged on a fixed schedule regardless of game speed.</da>
         </text>
-        <text name="wc_about_formulas_body">
-            <en>Wages are calculated one of two ways, chosen in the Wage Settings tab.
-
-HOURLY
-A fixed rate per worker for every hour they stay active. More workers and longer shifts mean a bigger bill.
-
-PER HECTARE
-You pay for the area each worker actually covers. Small jobs cost little; large fields cost more.
-
-Both modes scale with your Wage Level. The panel on the right shows your current rate, mode and the three tiers, live from your settings.</en>
-            <de>[EN] Wages are calculated one of two ways, chosen in the Wage Settings tab. HOURLY: a fixed rate per worker per hour. PER HECTARE: you pay for the area each worker covers. Both scale with your Wage Level.</de>
-            <fr>[EN] Wages are calculated one of two ways, chosen in the Wage Settings tab. HOURLY: a fixed rate per worker per hour. PER HECTARE: you pay for the area each worker covers. Both scale with your Wage Level.</fr>
-            <es>[EN] Wages are calculated one of two ways, chosen in the Wage Settings tab. HOURLY: a fixed rate per worker per hour. PER HECTARE: you pay for the area each worker covers. Both scale with your Wage Level.</es>
-            <pl>[EN] Wages are calculated one of two ways, chosen in the Wage Settings tab. HOURLY: a fixed rate per worker per hour. PER HECTARE: you pay for the area each worker covers. Both scale with your Wage Level.</pl>
-            <it>[EN] Wages are calculated one of two ways, chosen in the Wage Settings tab. HOURLY: a fixed rate per worker per hour. PER HECTARE: you pay for the area each worker covers. Both scale with your Wage Level.</it>
-            <cz>[EN] Wages are calculated one of two ways, chosen in the Wage Settings tab. HOURLY: a fixed rate per worker per hour. PER HECTARE: you pay for the area each worker covers. Both scale with your Wage Level.</cz>
-            <br>[EN] Wages are calculated one of two ways, chosen in the Wage Settings tab. HOURLY: a fixed rate per worker per hour. PER HECTARE: you pay for the area each worker covers. Both scale with your Wage Level.</br>
-            <uk>[EN] Wages are calculated one of two ways, chosen in the Wage Settings tab. HOURLY: a fixed rate per worker per hour. PER HECTARE: you pay for the area each worker covers. Both scale with your Wage Level.</uk>
-            <ru>[EN] Wages are calculated one of two ways, chosen in the Wage Settings tab. HOURLY: a fixed rate per worker per hour. PER HECTARE: you pay for the area each worker covers. Both scale with your Wage Level.</ru>
-            <da>[EN] Wages are calculated one of two ways, chosen in the Wage Settings tab. HOURLY: a fixed rate per worker per hour. PER HECTARE: you pay for the area each worker covers. Both scale with your Wage Level.</da>
+        <text name="wc_about_h_save">
+            <en>Saved Per Game</en>
+            <de>[EN] Saved Per Game</de>
+            <fr>[EN] Saved Per Game</fr>
+            <es>[EN] Saved Per Game</es>
+            <pl>[EN] Saved Per Game</pl>
+            <it>[EN] Saved Per Game</it>
+            <cz>[EN] Saved Per Game</cz>
+            <br>[EN] Saved Per Game</br>
+            <uk>[EN] Saved Per Game</uk>
+            <ru>[EN] Saved Per Game</ru>
+            <da>[EN] Saved Per Game</da>
         </text>
-        <text name="wc_about_staff_body">
-            <en>Pro-Staff gives workers a career instead of treating them as interchangeable.
-
-EXPERIENCE &amp; LEVELS
-Workers earn XP as they finish jobs and level up over time. Higher levels mean a more capable, more valuable hand.
-
-MASTERY
-Repeating a kind of work builds mastery in it, improving how efficiently that worker handles those tasks.
-
-FATIGUE
-Long shifts build fatigue, and a tired worker is less effective. Rotating staff and giving lighter days keeps the roster sharp.</en>
-            <de>[EN] Pro-Staff gives workers a career. They earn XP and level up, build mastery by repeating work, and accumulate fatigue on long shifts.</de>
-            <fr>[EN] Pro-Staff gives workers a career. They earn XP and level up, build mastery by repeating work, and accumulate fatigue on long shifts.</fr>
-            <es>[EN] Pro-Staff gives workers a career. They earn XP and level up, build mastery by repeating work, and accumulate fatigue on long shifts.</es>
-            <pl>[EN] Pro-Staff gives workers a career. They earn XP and level up, build mastery by repeating work, and accumulate fatigue on long shifts.</pl>
-            <it>[EN] Pro-Staff gives workers a career. They earn XP and level up, build mastery by repeating work, and accumulate fatigue on long shifts.</it>
-            <cz>[EN] Pro-Staff gives workers a career. They earn XP and level up, build mastery by repeating work, and accumulate fatigue on long shifts.</cz>
-            <br>[EN] Pro-Staff gives workers a career. They earn XP and level up, build mastery by repeating work, and accumulate fatigue on long shifts.</br>
-            <uk>[EN] Pro-Staff gives workers a career. They earn XP and level up, build mastery by repeating work, and accumulate fatigue on long shifts.</uk>
-            <ru>[EN] Pro-Staff gives workers a career. They earn XP and level up, build mastery by repeating work, and accumulate fatigue on long shifts.</ru>
-            <da>[EN] Pro-Staff gives workers a career. They earn XP and level up, build mastery by repeating work, and accumulate fatigue on long shifts.</da>
+        <text name="wc_about_save_body">
+            <en>Your cost mode, wage level and notification settings are stored per save game and restored on load. In multiplayer, clients stay in sync with the host.</en>
+            <de>[EN] Cost mode, wage level and notifications are saved per game and restored on load. MP clients stay in sync with the host.</de>
+            <fr>[EN] Cost mode, wage level and notifications are saved per game and restored on load. MP clients stay in sync with the host.</fr>
+            <es>[EN] Cost mode, wage level and notifications are saved per game and restored on load. MP clients stay in sync with the host.</es>
+            <pl>[EN] Cost mode, wage level and notifications are saved per game and restored on load. MP clients stay in sync with the host.</pl>
+            <it>[EN] Cost mode, wage level and notifications are saved per game and restored on load. MP clients stay in sync with the host.</it>
+            <cz>[EN] Cost mode, wage level and notifications are saved per game and restored on load. MP clients stay in sync with the host.</cz>
+            <br>[EN] Cost mode, wage level and notifications are saved per game and restored on load. MP clients stay in sync with the host.</br>
+            <uk>[EN] Cost mode, wage level and notifications are saved per game and restored on load. MP clients stay in sync with the host.</uk>
+            <ru>[EN] Cost mode, wage level and notifications are saved per game and restored on load. MP clients stay in sync with the host.</ru>
+            <da>[EN] Cost mode, wage level and notifications are saved per game and restored on load. MP clients stay in sync with the host.</da>
+        </text>
+        <text name="wc_about_hourly_body">
+            <en>A fixed rate per worker for every hour they stay active. The more workers you run and the longer they work, the bigger the bill.</en>
+            <de>[EN] A fixed rate per worker per active hour. More workers and longer shifts mean a bigger bill.</de>
+            <fr>[EN] A fixed rate per worker per active hour. More workers and longer shifts mean a bigger bill.</fr>
+            <es>[EN] A fixed rate per worker per active hour. More workers and longer shifts mean a bigger bill.</es>
+            <pl>[EN] A fixed rate per worker per active hour. More workers and longer shifts mean a bigger bill.</pl>
+            <it>[EN] A fixed rate per worker per active hour. More workers and longer shifts mean a bigger bill.</it>
+            <cz>[EN] A fixed rate per worker per active hour. More workers and longer shifts mean a bigger bill.</cz>
+            <br>[EN] A fixed rate per worker per active hour. More workers and longer shifts mean a bigger bill.</br>
+            <uk>[EN] A fixed rate per worker per active hour. More workers and longer shifts mean a bigger bill.</uk>
+            <ru>[EN] A fixed rate per worker per active hour. More workers and longer shifts mean a bigger bill.</ru>
+            <da>[EN] A fixed rate per worker per active hour. More workers and longer shifts mean a bigger bill.</da>
+        </text>
+        <text name="wc_about_hectare_body">
+            <en>You pay for the area each worker actually covers. Light jobs cost little, large fields cost more. Both modes scale with your Wage Level; the panel on the right shows your live rate, mode and tiers.</en>
+            <de>[EN] You pay for the area each worker covers. Both modes scale with your Wage Level; the right panel shows your live rate, mode and tiers.</de>
+            <fr>[EN] You pay for the area each worker covers. Both modes scale with your Wage Level; the right panel shows your live rate, mode and tiers.</fr>
+            <es>[EN] You pay for the area each worker covers. Both modes scale with your Wage Level; the right panel shows your live rate, mode and tiers.</es>
+            <pl>[EN] You pay for the area each worker covers. Both modes scale with your Wage Level; the right panel shows your live rate, mode and tiers.</pl>
+            <it>[EN] You pay for the area each worker covers. Both modes scale with your Wage Level; the right panel shows your live rate, mode and tiers.</it>
+            <cz>[EN] You pay for the area each worker covers. Both modes scale with your Wage Level; the right panel shows your live rate, mode and tiers.</cz>
+            <br>[EN] You pay for the area each worker covers. Both modes scale with your Wage Level; the right panel shows your live rate, mode and tiers.</br>
+            <uk>[EN] You pay for the area each worker covers. Both modes scale with your Wage Level; the right panel shows your live rate, mode and tiers.</uk>
+            <ru>[EN] You pay for the area each worker covers. Both modes scale with your Wage Level; the right panel shows your live rate, mode and tiers.</ru>
+            <da>[EN] You pay for the area each worker covers. Both modes scale with your Wage Level; the right panel shows your live rate, mode and tiers.</da>
+        </text>
+        <text name="wc_about_h_xp">
+            <en>Experience &amp; Levels</en>
+            <de>[EN] Experience &amp; Levels</de>
+            <fr>[EN] Experience &amp; Levels</fr>
+            <es>[EN] Experience &amp; Levels</es>
+            <pl>[EN] Experience &amp; Levels</pl>
+            <it>[EN] Experience &amp; Levels</it>
+            <cz>[EN] Experience &amp; Levels</cz>
+            <br>[EN] Experience &amp; Levels</br>
+            <uk>[EN] Experience &amp; Levels</uk>
+            <ru>[EN] Experience &amp; Levels</ru>
+            <da>[EN] Experience &amp; Levels</da>
+        </text>
+        <text name="wc_about_xp_body">
+            <en>Workers earn XP as they finish jobs and level up over time. A higher level means a more capable, more valuable hand.</en>
+            <de>[EN] Workers earn XP as they finish jobs and level up. Higher levels mean a more capable, more valuable hand.</de>
+            <fr>[EN] Workers earn XP as they finish jobs and level up. Higher levels mean a more capable, more valuable hand.</fr>
+            <es>[EN] Workers earn XP as they finish jobs and level up. Higher levels mean a more capable, more valuable hand.</es>
+            <pl>[EN] Workers earn XP as they finish jobs and level up. Higher levels mean a more capable, more valuable hand.</pl>
+            <it>[EN] Workers earn XP as they finish jobs and level up. Higher levels mean a more capable, more valuable hand.</it>
+            <cz>[EN] Workers earn XP as they finish jobs and level up. Higher levels mean a more capable, more valuable hand.</cz>
+            <br>[EN] Workers earn XP as they finish jobs and level up. Higher levels mean a more capable, more valuable hand.</br>
+            <uk>[EN] Workers earn XP as they finish jobs and level up. Higher levels mean a more capable, more valuable hand.</uk>
+            <ru>[EN] Workers earn XP as they finish jobs and level up. Higher levels mean a more capable, more valuable hand.</ru>
+            <da>[EN] Workers earn XP as they finish jobs and level up. Higher levels mean a more capable, more valuable hand.</da>
+        </text>
+        <text name="wc_about_h_mastery">
+            <en>Mastery</en>
+            <de>[EN] Mastery</de>
+            <fr>[EN] Mastery</fr>
+            <es>[EN] Mastery</es>
+            <pl>[EN] Mastery</pl>
+            <it>[EN] Mastery</it>
+            <cz>[EN] Mastery</cz>
+            <br>[EN] Mastery</br>
+            <uk>[EN] Mastery</uk>
+            <ru>[EN] Mastery</ru>
+            <da>[EN] Mastery</da>
+        </text>
+        <text name="wc_about_mastery_body">
+            <en>Repeating a kind of work builds mastery in it, improving how efficiently that worker handles those tasks.</en>
+            <de>[EN] Repeating a kind of work builds mastery in it, improving how efficiently that worker handles those tasks.</de>
+            <fr>[EN] Repeating a kind of work builds mastery in it, improving how efficiently that worker handles those tasks.</fr>
+            <es>[EN] Repeating a kind of work builds mastery in it, improving how efficiently that worker handles those tasks.</es>
+            <pl>[EN] Repeating a kind of work builds mastery in it, improving how efficiently that worker handles those tasks.</pl>
+            <it>[EN] Repeating a kind of work builds mastery in it, improving how efficiently that worker handles those tasks.</it>
+            <cz>[EN] Repeating a kind of work builds mastery in it, improving how efficiently that worker handles those tasks.</cz>
+            <br>[EN] Repeating a kind of work builds mastery in it, improving how efficiently that worker handles those tasks.</br>
+            <uk>[EN] Repeating a kind of work builds mastery in it, improving how efficiently that worker handles those tasks.</uk>
+            <ru>[EN] Repeating a kind of work builds mastery in it, improving how efficiently that worker handles those tasks.</ru>
+            <da>[EN] Repeating a kind of work builds mastery in it, improving how efficiently that worker handles those tasks.</da>
+        </text>
+        <text name="wc_about_h_fatigue">
+            <en>Fatigue</en>
+            <de>[EN] Fatigue</de>
+            <fr>[EN] Fatigue</fr>
+            <es>[EN] Fatigue</es>
+            <pl>[EN] Fatigue</pl>
+            <it>[EN] Fatigue</it>
+            <cz>[EN] Fatigue</cz>
+            <br>[EN] Fatigue</br>
+            <uk>[EN] Fatigue</uk>
+            <ru>[EN] Fatigue</ru>
+            <da>[EN] Fatigue</da>
+        </text>
+        <text name="wc_about_fatigue_body">
+            <en>Long shifts build fatigue, and a tired worker is less effective. Rotate your staff and give them lighter days to keep the whole roster sharp.</en>
+            <de>[EN] Long shifts build fatigue and a tired worker is less effective. Rotate staff and give lighter days to keep the roster sharp.</de>
+            <fr>[EN] Long shifts build fatigue and a tired worker is less effective. Rotate staff and give lighter days to keep the roster sharp.</fr>
+            <es>[EN] Long shifts build fatigue and a tired worker is less effective. Rotate staff and give lighter days to keep the roster sharp.</es>
+            <pl>[EN] Long shifts build fatigue and a tired worker is less effective. Rotate staff and give lighter days to keep the roster sharp.</pl>
+            <it>[EN] Long shifts build fatigue and a tired worker is less effective. Rotate staff and give lighter days to keep the roster sharp.</it>
+            <cz>[EN] Long shifts build fatigue and a tired worker is less effective. Rotate staff and give lighter days to keep the roster sharp.</cz>
+            <br>[EN] Long shifts build fatigue and a tired worker is less effective. Rotate staff and give lighter days to keep the roster sharp.</br>
+            <uk>[EN] Long shifts build fatigue and a tired worker is less effective. Rotate staff and give lighter days to keep the roster sharp.</uk>
+            <ru>[EN] Long shifts build fatigue and a tired worker is less effective. Rotate staff and give lighter days to keep the roster sharp.</ru>
+            <da>[EN] Long shifts build fatigue and a tired worker is less effective. Rotate staff and give lighter days to keep the roster sharp.</da>
+        </text>
+        <text name="wc_about_h_tips">
+            <en>Tips</en>
+            <de>[EN] Tips</de>
+            <fr>[EN] Tips</fr>
+            <es>[EN] Tips</es>
+            <pl>[EN] Tips</pl>
+            <it>[EN] Tips</it>
+            <cz>[EN] Tips</cz>
+            <br>[EN] Tips</br>
+            <uk>[EN] Tips</uk>
+            <ru>[EN] Tips</ru>
+            <da>[EN] Tips</da>
+        </text>
+        <text name="wc_about_tips_body">
+            <en>Check the Dashboard for a live per-worker cost breakdown, and use the Wage Settings tab to switch cost mode or wage level.</en>
+            <de>[EN] Check the Dashboard for a live per-worker cost breakdown, and the Wage Settings tab to switch cost mode or wage level.</de>
+            <fr>[EN] Check the Dashboard for a live per-worker cost breakdown, and the Wage Settings tab to switch cost mode or wage level.</fr>
+            <es>[EN] Check the Dashboard for a live per-worker cost breakdown, and the Wage Settings tab to switch cost mode or wage level.</es>
+            <pl>[EN] Check the Dashboard for a live per-worker cost breakdown, and the Wage Settings tab to switch cost mode or wage level.</pl>
+            <it>[EN] Check the Dashboard for a live per-worker cost breakdown, and the Wage Settings tab to switch cost mode or wage level.</it>
+            <cz>[EN] Check the Dashboard for a live per-worker cost breakdown, and the Wage Settings tab to switch cost mode or wage level.</cz>
+            <br>[EN] Check the Dashboard for a live per-worker cost breakdown, and the Wage Settings tab to switch cost mode or wage level.</br>
+            <uk>[EN] Check the Dashboard for a live per-worker cost breakdown, and the Wage Settings tab to switch cost mode or wage level.</uk>
+            <ru>[EN] Check the Dashboard for a live per-worker cost breakdown, and the Wage Settings tab to switch cost mode or wage level.</ru>
+            <da>[EN] Check the Dashboard for a live per-worker cost breakdown, and the Wage Settings tab to switch cost mode or wage level.</da>
         </text>
 
         <text name="wc_label_version">

--- a/modDesc.xml
+++ b/modDesc.xml
@@ -864,6 +864,141 @@
         </text>
 
         <!-- About frame -->
+        <!-- #80: sub-tab labels (Core / Formulas / Pro-Staff) -->
+        <text name="wc_about_tab_core">
+            <en>Core</en>
+            <de>[EN] Core</de>
+            <fr>[EN] Core</fr>
+            <es>[EN] Core</es>
+            <pl>[EN] Core</pl>
+            <it>[EN] Core</it>
+            <cz>[EN] Core</cz>
+            <br>[EN] Core</br>
+            <uk>[EN] Core</uk>
+            <ru>[EN] Core</ru>
+            <da>[EN] Core</da>
+        </text>
+        <text name="wc_about_tab_formulas">
+            <en>Formulas</en>
+            <de>[EN] Formulas</de>
+            <fr>[EN] Formulas</fr>
+            <es>[EN] Formulas</es>
+            <pl>[EN] Formulas</pl>
+            <it>[EN] Formulas</it>
+            <cz>[EN] Formulas</cz>
+            <br>[EN] Formulas</br>
+            <uk>[EN] Formulas</uk>
+            <ru>[EN] Formulas</ru>
+            <da>[EN] Formulas</da>
+        </text>
+        <text name="wc_about_tab_staff">
+            <en>Pro-Staff</en>
+            <de>[EN] Pro-Staff</de>
+            <fr>[EN] Pro-Staff</fr>
+            <es>[EN] Pro-Staff</es>
+            <pl>[EN] Pro-Staff</pl>
+            <it>[EN] Pro-Staff</it>
+            <cz>[EN] Pro-Staff</cz>
+            <br>[EN] Pro-Staff</br>
+            <uk>[EN] Pro-Staff</uk>
+            <ru>[EN] Pro-Staff</ru>
+            <da>[EN] Pro-Staff</da>
+        </text>
+
+        <!-- #80: cost-mode value labels for the Formulas tab config block -->
+        <text name="wc_cost_mode_hourly">
+            <en>Hourly</en>
+            <de>[EN] Hourly</de>
+            <fr>[EN] Hourly</fr>
+            <es>[EN] Hourly</es>
+            <pl>[EN] Hourly</pl>
+            <it>[EN] Hourly</it>
+            <cz>[EN] Hourly</cz>
+            <br>[EN] Hourly</br>
+            <uk>[EN] Hourly</uk>
+            <ru>[EN] Hourly</ru>
+            <da>[EN] Hourly</da>
+        </text>
+        <text name="wc_cost_mode_hectare">
+            <en>Per Hectare</en>
+            <de>[EN] Per Hectare</de>
+            <fr>[EN] Per Hectare</fr>
+            <es>[EN] Per Hectare</es>
+            <pl>[EN] Per Hectare</pl>
+            <it>[EN] Per Hectare</it>
+            <cz>[EN] Per Hectare</cz>
+            <br>[EN] Per Hectare</br>
+            <uk>[EN] Per Hectare</uk>
+            <ru>[EN] Per Hectare</ru>
+            <da>[EN] Per Hectare</da>
+        </text>
+
+        <!-- #80: per-tab body content -->
+        <text name="wc_about_core_body">
+            <en>Realistic Worker Costs replaces the default pay system with a billing model based on real time.
+
+Each active AI worker is charged on a fixed schedule, no matter the game speed. Deductions happen quietly in the background every payment interval.
+
+REAL-TIME BILLING
+Tying wages to real minutes keeps costs predictable at any time scale. Fast-forwarding a season no longer drains your account.
+
+SAVE PERSISTENCE
+Cost mode, wage level and notification settings are saved per save game and restored on load. Multiplayer clients stay in sync with the host.</en>
+            <de>[EN] Realistic Worker Costs replaces the default pay system with a billing model based on real time. Each active AI worker is charged on a fixed schedule, no matter the game speed.</de>
+            <fr>[EN] Realistic Worker Costs replaces the default pay system with a billing model based on real time. Each active AI worker is charged on a fixed schedule, no matter the game speed.</fr>
+            <es>[EN] Realistic Worker Costs replaces the default pay system with a billing model based on real time. Each active AI worker is charged on a fixed schedule, no matter the game speed.</es>
+            <pl>[EN] Realistic Worker Costs replaces the default pay system with a billing model based on real time. Each active AI worker is charged on a fixed schedule, no matter the game speed.</pl>
+            <it>[EN] Realistic Worker Costs replaces the default pay system with a billing model based on real time. Each active AI worker is charged on a fixed schedule, no matter the game speed.</it>
+            <cz>[EN] Realistic Worker Costs replaces the default pay system with a billing model based on real time. Each active AI worker is charged on a fixed schedule, no matter the game speed.</cz>
+            <br>[EN] Realistic Worker Costs replaces the default pay system with a billing model based on real time. Each active AI worker is charged on a fixed schedule, no matter the game speed.</br>
+            <uk>[EN] Realistic Worker Costs replaces the default pay system with a billing model based on real time. Each active AI worker is charged on a fixed schedule, no matter the game speed.</uk>
+            <ru>[EN] Realistic Worker Costs replaces the default pay system with a billing model based on real time. Each active AI worker is charged on a fixed schedule, no matter the game speed.</ru>
+            <da>[EN] Realistic Worker Costs replaces the default pay system with a billing model based on real time. Each active AI worker is charged on a fixed schedule, no matter the game speed.</da>
+        </text>
+        <text name="wc_about_formulas_body">
+            <en>Wages are calculated one of two ways, chosen in the Wage Settings tab.
+
+HOURLY
+A fixed rate per worker for every hour they stay active. More workers and longer shifts mean a bigger bill.
+
+PER HECTARE
+You pay for the area each worker actually covers. Small jobs cost little; large fields cost more.
+
+Both modes scale with your Wage Level. The panel on the right shows your current rate, mode and the three tiers, live from your settings.</en>
+            <de>[EN] Wages are calculated one of two ways, chosen in the Wage Settings tab. HOURLY: a fixed rate per worker per hour. PER HECTARE: you pay for the area each worker covers. Both scale with your Wage Level.</de>
+            <fr>[EN] Wages are calculated one of two ways, chosen in the Wage Settings tab. HOURLY: a fixed rate per worker per hour. PER HECTARE: you pay for the area each worker covers. Both scale with your Wage Level.</fr>
+            <es>[EN] Wages are calculated one of two ways, chosen in the Wage Settings tab. HOURLY: a fixed rate per worker per hour. PER HECTARE: you pay for the area each worker covers. Both scale with your Wage Level.</es>
+            <pl>[EN] Wages are calculated one of two ways, chosen in the Wage Settings tab. HOURLY: a fixed rate per worker per hour. PER HECTARE: you pay for the area each worker covers. Both scale with your Wage Level.</pl>
+            <it>[EN] Wages are calculated one of two ways, chosen in the Wage Settings tab. HOURLY: a fixed rate per worker per hour. PER HECTARE: you pay for the area each worker covers. Both scale with your Wage Level.</it>
+            <cz>[EN] Wages are calculated one of two ways, chosen in the Wage Settings tab. HOURLY: a fixed rate per worker per hour. PER HECTARE: you pay for the area each worker covers. Both scale with your Wage Level.</cz>
+            <br>[EN] Wages are calculated one of two ways, chosen in the Wage Settings tab. HOURLY: a fixed rate per worker per hour. PER HECTARE: you pay for the area each worker covers. Both scale with your Wage Level.</br>
+            <uk>[EN] Wages are calculated one of two ways, chosen in the Wage Settings tab. HOURLY: a fixed rate per worker per hour. PER HECTARE: you pay for the area each worker covers. Both scale with your Wage Level.</uk>
+            <ru>[EN] Wages are calculated one of two ways, chosen in the Wage Settings tab. HOURLY: a fixed rate per worker per hour. PER HECTARE: you pay for the area each worker covers. Both scale with your Wage Level.</ru>
+            <da>[EN] Wages are calculated one of two ways, chosen in the Wage Settings tab. HOURLY: a fixed rate per worker per hour. PER HECTARE: you pay for the area each worker covers. Both scale with your Wage Level.</da>
+        </text>
+        <text name="wc_about_staff_body">
+            <en>Pro-Staff gives workers a career instead of treating them as interchangeable.
+
+EXPERIENCE &amp; LEVELS
+Workers earn XP as they finish jobs and level up over time. Higher levels mean a more capable, more valuable hand.
+
+MASTERY
+Repeating a kind of work builds mastery in it, improving how efficiently that worker handles those tasks.
+
+FATIGUE
+Long shifts build fatigue, and a tired worker is less effective. Rotating staff and giving lighter days keeps the roster sharp.</en>
+            <de>[EN] Pro-Staff gives workers a career. They earn XP and level up, build mastery by repeating work, and accumulate fatigue on long shifts.</de>
+            <fr>[EN] Pro-Staff gives workers a career. They earn XP and level up, build mastery by repeating work, and accumulate fatigue on long shifts.</fr>
+            <es>[EN] Pro-Staff gives workers a career. They earn XP and level up, build mastery by repeating work, and accumulate fatigue on long shifts.</es>
+            <pl>[EN] Pro-Staff gives workers a career. They earn XP and level up, build mastery by repeating work, and accumulate fatigue on long shifts.</pl>
+            <it>[EN] Pro-Staff gives workers a career. They earn XP and level up, build mastery by repeating work, and accumulate fatigue on long shifts.</it>
+            <cz>[EN] Pro-Staff gives workers a career. They earn XP and level up, build mastery by repeating work, and accumulate fatigue on long shifts.</cz>
+            <br>[EN] Pro-Staff gives workers a career. They earn XP and level up, build mastery by repeating work, and accumulate fatigue on long shifts.</br>
+            <uk>[EN] Pro-Staff gives workers a career. They earn XP and level up, build mastery by repeating work, and accumulate fatigue on long shifts.</uk>
+            <ru>[EN] Pro-Staff gives workers a career. They earn XP and level up, build mastery by repeating work, and accumulate fatigue on long shifts.</ru>
+            <da>[EN] Pro-Staff gives workers a career. They earn XP and level up, build mastery by repeating work, and accumulate fatigue on long shifts.</da>
+        </text>
+
         <text name="wc_label_version">
             <en>VERSION</en>
             <de>VERSION</de>

--- a/src/gui/WCAboutFrame.lua
+++ b/src/gui/WCAboutFrame.lua
@@ -3,16 +3,30 @@
 -- WCAboutFrame.lua  -  Tab 4: About / Help
 -- =========================================================
 -- Author: TisonK
+-- #80: modular tabbed layout (Core / Formulas / Pro-Staff). All three panels
+-- are pre-loaded from the XML; switching is a pure index-based visibility
+-- toggle (no g_gui:loadGui or file parsing at runtime), per the issue spec.
 -- =========================================================
 
 ---@class WCAboutFrame
 WCAboutFrame = {}
 local WCAboutFrame_mt = Class(WCAboutFrame, TabbedMenuFrameElement)
 
+-- Sub-tab indices
+WCAboutFrame.TAB_CORE     = 1
+WCAboutFrame.TAB_FORMULAS = 2
+WCAboutFrame.TAB_STAFF    = 3
+
+-- Tab-button background colours (active / inactive / hover)
+local COL_ACTIVE   = { 0.22, 0.50, 0.22, 0.95 }
+local COL_INACTIVE = { 0.13, 0.27, 0.13, 0.85 }
+local COL_HOVER    = { 0.30, 0.62, 0.30, 0.98 }
+
 function WCAboutFrame.new()
     local self = WCAboutFrame:superClass().new(nil, WCAboutFrame_mt)
-    self.name      = "WCAboutFrame"
-    self.className = "WCAboutFrame"
+    self.name       = "WCAboutFrame"
+    self.className   = "WCAboutFrame"
+    self.currentTab = WCAboutFrame.TAB_CORE
     return self
 end
 
@@ -26,6 +40,7 @@ end
 
 function WCAboutFrame:onFrameOpen()
     WCAboutFrame:superClass().onFrameOpen(self)
+    self:selectTab(self.currentTab or WCAboutFrame.TAB_CORE)
     self:refresh()
 end
 
@@ -33,27 +48,80 @@ function WCAboutFrame:onFrameClose()
     WCAboutFrame:superClass().onFrameClose(self)
 end
 
+-- ── Sub-tab switching ────────────────────────────────────────────────────
+-- Index-based visibility toggle: zero runtime allocation, instant switch.
+function WCAboutFrame:selectTab(index)
+    self.currentTab = index
+    if self.paneCore     ~= nil then self.paneCore:setVisible(index == WCAboutFrame.TAB_CORE)        end
+    if self.paneFormulas ~= nil then self.paneFormulas:setVisible(index == WCAboutFrame.TAB_FORMULAS) end
+    if self.paneStaff    ~= nil then self.paneStaff:setVisible(index == WCAboutFrame.TAB_STAFF)       end
+    self:applyTabColors()
+end
+
+function WCAboutFrame:applyTabColors()
+    self:setBgColor(self.btnTabCoreBg,     self.currentTab == WCAboutFrame.TAB_CORE)
+    self:setBgColor(self.btnTabFormulasBg, self.currentTab == WCAboutFrame.TAB_FORMULAS)
+    self:setBgColor(self.btnTabStaffBg,    self.currentTab == WCAboutFrame.TAB_STAFF)
+end
+
+function WCAboutFrame:setBgColor(el, isActive)
+    if el == nil then return end
+    local c = isActive and COL_ACTIVE or COL_INACTIVE
+    el:setImageColor(c[1], c[2], c[3], c[4])
+end
+
+-- Click handlers (wired from XML onClick=)
+function WCAboutFrame:onClickTabCore()     self:selectTab(WCAboutFrame.TAB_CORE);     self:refresh() end
+function WCAboutFrame:onClickTabFormulas() self:selectTab(WCAboutFrame.TAB_FORMULAS); self:refresh() end
+function WCAboutFrame:onClickTabStaff()    self:selectTab(WCAboutFrame.TAB_STAFF);    self:refresh() end
+
+-- Hover highlight. On leave we restore the correct active/inactive colour
+-- so hovering never leaves a tab stuck in the wrong state.
+function WCAboutFrame:onTabCoreFocus()     self:setBgColor(self.btnTabCoreBg, true);     if self.btnTabCoreBg     then self.btnTabCoreBg:setImageColor(COL_HOVER[1], COL_HOVER[2], COL_HOVER[3], COL_HOVER[4])     end end
+function WCAboutFrame:onTabFormulasFocus() if self.btnTabFormulasBg then self.btnTabFormulasBg:setImageColor(COL_HOVER[1], COL_HOVER[2], COL_HOVER[3], COL_HOVER[4]) end end
+function WCAboutFrame:onTabStaffFocus()    if self.btnTabStaffBg    then self.btnTabStaffBg:setImageColor(COL_HOVER[1], COL_HOVER[2], COL_HOVER[3], COL_HOVER[4])    end end
+function WCAboutFrame:onTabCoreLeave()     self:applyTabColors() end
+function WCAboutFrame:onTabFormulasLeave() self:applyTabColors() end
+function WCAboutFrame:onTabStaffLeave()    self:applyTabColors() end
+
+-- ── Dynamic data binding ─────────────────────────────────────────────────
 function WCAboutFrame:refresh()
-    -- Pay interval from workerSystem
-    if self.txtPayInterval and g_WorkerManager and g_WorkerManager.workerSystem then
-        local min = math.floor(g_WorkerManager.workerSystem.paymentInterval / 60000)
+    local wm       = g_WorkerManager
+    local settings = wm and wm.settings
+
+    -- Core panel: payment interval
+    if self.txtPayInterval and wm and wm.workerSystem then
+        local min = math.floor(wm.workerSystem.paymentInterval / 60000)
         self.txtPayInterval:setText(string.format("%d min", min))
     end
 
-    -- Mod version: try the stored modName (captured at load time), then the folder name fallback
+    -- Core panel: live mod version (modName captured at load, folder-name fallback)
     if self.txtVersion then
         local version = "unknown"
         if g_modManager then
-            local modName = (g_WorkerManager and g_WorkerManager.modName) or "FS25_WorkerCosts"
+            local modName = (wm and wm.modName) or "FS25_WorkerCosts"
             local mod = g_modManager:getModByName(modName)
-            -- Some FS25 builds key by folder name rather than <modName>; try both
             if not (mod and mod.version) then
                 mod = g_modManager:getModByName("FS25_WorkerCosts")
             end
-            if mod and mod.version then
-                version = mod.version
-            end
+            if mod and mod.version then version = mod.version end
         end
         self.txtVersion:setText(version)
+    end
+
+    -- Formulas panel: bind the live effective rate / mode to the Settings model
+    -- so it always reflects the player's current configuration.
+    if settings ~= nil then
+        local rate     = settings:getWageRate()
+        local isHourly = settings.costMode == Settings.COST_MODE_HOURLY
+        if self.txtEffRate then
+            self.txtEffRate:setText(string.format(isHourly and "$%d / h" or "$%d / ha", rate))
+        end
+        if self.txtRateLabel then
+            self.txtRateLabel:setText(settings:getWageLevelName())
+        end
+        if self.txtCostMode then
+            self.txtCostMode:setText(g_i18n:getText(isHourly and "wc_cost_mode_hourly" or "wc_cost_mode_hectare"))
+        end
     end
 end

--- a/src/main.lua
+++ b/src/main.lua
@@ -218,4 +218,4 @@ end
 getfenv(0)["workerCosts"]       = workerCosts
 getfenv(0)["workerCostsStatus"] = workerCostsStatus
 
-Logging.info("[Worker Costs] v2.2.1.0 loaded — type 'workerCosts' in console for help")
+Logging.info("[Worker Costs] v2.2.2.0 loaded — type 'workerCosts' in console for help")

--- a/xml/gui/WCAboutFrame.xml
+++ b/xml/gui/WCAboutFrame.xml
@@ -14,7 +14,6 @@
 
             <!-- ============================================================ -->
             <!-- Sub-tab selector (#80): three buttons toggle the panels below -->
-            <!-- via index-based visibility. No g_gui:loadGui at runtime.       -->
             <!-- ============================================================ -->
             <Bitmap profile="WC_BtnBgGreen" id="btnTabCoreBg" position="0px 24px" size="336px 44px"/>
             <Button profile="WC_BtnHit" position="0px 24px" size="336px 44px"
@@ -36,13 +35,17 @@
             <!-- ============================================================ -->
             <GuiElement id="paneCore" position="0px -40px" size="1040px 520px">
 
-                <!-- LEFT: how it works body text -->
+                <!-- LEFT: sectioned "how it works" -->
                 <ThreePartBitmap profile="fs25_primaryMenuContainerBg" width="580px" height="500px" position="0px 0px">
                     <Bitmap profile="fs25_menuContainerArrow"/>
                     <GuiElement profile="fs25_subCategoryContainer" width="540px">
                         <Text profile="WC_SectionTitle" position="10px -10px" text="$l10n_wc_section_how_it_works"/>
                         <ThreePartBitmap profile="fs25_lineSeparatorTop" position="5px -34px" width="520px"/>
-                        <Text profile="WC_BodyText" position="10px -54px" size="520px 440px" textMaxNumLines="22" text="$l10n_wc_about_core_body"/>
+                        <Text profile="WC_BodyText" position="10px -54px" size="520px 180px" textMaxNumLines="9" text="$l10n_wc_about_core_intro"/>
+
+                        <Text profile="WC_SectionTitle" position="10px -250px" text="$l10n_wc_about_h_save"/>
+                        <ThreePartBitmap profile="fs25_lineSeparatorTop" position="5px -274px" width="520px"/>
+                        <Text profile="WC_BodyText" position="10px -294px" size="520px 150px" textMaxNumLines="7" text="$l10n_wc_about_save_body"/>
                     </GuiElement>
                 </ThreePartBitmap>
 
@@ -72,13 +75,17 @@
             <!-- ============================================================ -->
             <GuiElement id="paneFormulas" position="0px -40px" size="1040px 520px">
 
-                <!-- LEFT: how wages are calculated -->
+                <!-- LEFT: how wages are calculated, one section per mode -->
                 <ThreePartBitmap profile="fs25_primaryMenuContainerBg" width="580px" height="500px" position="0px 0px">
                     <Bitmap profile="fs25_menuContainerArrow"/>
                     <GuiElement profile="fs25_subCategoryContainer" width="540px">
-                        <Text profile="WC_SectionTitle" position="10px -10px" text="$l10n_wc_about_tab_formulas"/>
+                        <Text profile="WC_SectionTitle" position="10px -10px" text="$l10n_wc_cost_mode_hourly"/>
                         <ThreePartBitmap profile="fs25_lineSeparatorTop" position="5px -34px" width="520px"/>
-                        <Text profile="WC_BodyText" position="10px -54px" size="520px 440px" textMaxNumLines="22" text="$l10n_wc_about_formulas_body"/>
+                        <Text profile="WC_BodyText" position="10px -54px" size="520px 150px" textMaxNumLines="6" text="$l10n_wc_about_hourly_body"/>
+
+                        <Text profile="WC_SectionTitle" position="10px -220px" text="$l10n_wc_cost_mode_hectare"/>
+                        <ThreePartBitmap profile="fs25_lineSeparatorTop" position="5px -244px" width="520px"/>
+                        <Text profile="WC_BodyText" position="10px -264px" size="520px 180px" textMaxNumLines="8" text="$l10n_wc_about_hectare_body"/>
                     </GuiElement>
                 </ThreePartBitmap>
 
@@ -109,18 +116,37 @@
             </GuiElement>
 
             <!-- ============================================================ -->
-            <!-- PANEL 3 — PRO-STAFF: XP, fatigue, mastery overview            -->
+            <!-- PANEL 3 — PRO-STAFF: two columns, XP/Mastery | Fatigue        -->
             <!-- ============================================================ -->
             <GuiElement id="paneStaff" position="0px -40px" size="1040px 520px">
 
-                <ThreePartBitmap profile="fs25_primaryMenuContainerBg" width="1020px" height="500px" position="0px 0px">
+                <!-- LEFT: experience & mastery -->
+                <ThreePartBitmap profile="fs25_primaryMenuContainerBg" width="580px" height="500px" position="0px 0px">
                     <Bitmap profile="fs25_menuContainerArrow"/>
-                    <GuiElement profile="fs25_subCategoryContainer" width="980px">
-                        <Text profile="WC_SectionTitle" position="10px -10px" text="$l10n_wc_about_tab_staff"/>
-                        <ThreePartBitmap profile="fs25_lineSeparatorTop" position="5px -34px" width="960px"/>
-                        <Text profile="WC_BodyText" position="10px -54px" size="960px 440px" textMaxNumLines="22" text="$l10n_wc_about_staff_body"/>
+                    <GuiElement profile="fs25_subCategoryContainer" width="540px">
+                        <Text profile="WC_SectionTitle" position="10px -10px" text="$l10n_wc_about_h_xp"/>
+                        <ThreePartBitmap profile="fs25_lineSeparatorTop" position="5px -34px" width="520px"/>
+                        <Text profile="WC_BodyText" position="10px -54px" size="520px 150px" textMaxNumLines="6" text="$l10n_wc_about_xp_body"/>
+
+                        <Text profile="WC_SectionTitle" position="10px -220px" text="$l10n_wc_about_h_mastery"/>
+                        <ThreePartBitmap profile="fs25_lineSeparatorTop" position="5px -244px" width="520px"/>
+                        <Text profile="WC_BodyText" position="10px -264px" size="520px 180px" textMaxNumLines="8" text="$l10n_wc_about_mastery_body"/>
                     </GuiElement>
                 </ThreePartBitmap>
+
+                <Bitmap profile="fs25_settingsTooltipSeparator" position="596px -20px"/>
+
+                <!-- RIGHT: fatigue -->
+                <GuiElement position="614px 10px" width="420px" height="500px">
+                    <Text profile="WC_SectionTitle" position="0px -10px" text="$l10n_wc_about_h_fatigue"/>
+                    <ThreePartBitmap profile="fs25_lineSeparatorTop" position="0px -34px" width="400px"/>
+                    <Text profile="WC_BodyText" position="0px -54px" size="400px 200px" textMaxNumLines="9" text="$l10n_wc_about_fatigue_body"/>
+
+                    <ThreePartBitmap profile="fs25_lineSeparatorTop" position="0px -270px" width="400px"/>
+                    <Text profile="WC_SectionTitle" position="0px -290px" text="$l10n_wc_about_h_tips"/>
+                    <ThreePartBitmap profile="fs25_lineSeparatorTop" position="0px -314px" width="400px"/>
+                    <Text profile="WC_BodyText" position="0px -334px" size="400px 150px" textMaxNumLines="7" text="$l10n_wc_about_tips_body"/>
+                </GuiElement>
 
             </GuiElement>
 

--- a/xml/gui/WCAboutFrame.xml
+++ b/xml/gui/WCAboutFrame.xml
@@ -12,48 +12,115 @@
 
         <GuiElement profile="fs25_subCategorySelectorTabbedContainer" position="0px -80px">
 
-            <!-- LEFT: How it works body text -->
-            <ThreePartBitmap profile="fs25_primaryMenuContainerBg" width="580px" height="560px" position="0px 20px">
-                <Bitmap profile="fs25_menuContainerArrow"/>
-                <GuiElement profile="fs25_subCategoryContainer" width="540px">
+            <!-- ============================================================ -->
+            <!-- Sub-tab selector (#80): three buttons toggle the panels below -->
+            <!-- via index-based visibility. No g_gui:loadGui at runtime.       -->
+            <!-- ============================================================ -->
+            <Bitmap profile="WC_BtnBgGreen" id="btnTabCoreBg" position="0px 24px" size="336px 44px"/>
+            <Button profile="WC_BtnHit" position="0px 24px" size="336px 44px"
+                    onClick="onClickTabCore" onFocus="onTabCoreFocus" onLeave="onTabCoreLeave"/>
+            <Text profile="WC_BtnText" position="0px 24px" size="336px 44px" text="$l10n_wc_about_tab_core"/>
 
-                    <Text profile="WC_SectionTitle" position="10px -10px" text="$l10n_wc_section_how_it_works"/>
-                    <ThreePartBitmap profile="fs25_lineSeparatorTop" position="5px -34px" width="520px"/>
+            <Bitmap profile="WC_BtnBgGreen" id="btnTabFormulasBg" position="352px 24px" size="336px 44px"/>
+            <Button profile="WC_BtnHit" position="352px 24px" size="336px 44px"
+                    onClick="onClickTabFormulas" onFocus="onTabFormulasFocus" onLeave="onTabFormulasLeave"/>
+            <Text profile="WC_BtnText" position="352px 24px" size="336px 44px" text="$l10n_wc_about_tab_formulas"/>
 
-                    <Text profile="WC_BodyText" position="10px -54px" size="520px 500px" textMaxNumLines="24" text="$l10n_wc_about_body"/>
+            <Bitmap profile="WC_BtnBgGreen" id="btnTabStaffBg" position="704px 24px" size="336px 44px"/>
+            <Button profile="WC_BtnHit" position="704px 24px" size="336px 44px"
+                    onClick="onClickTabStaff" onFocus="onTabStaffFocus" onLeave="onTabStaffLeave"/>
+            <Text profile="WC_BtnText" position="704px 24px" size="336px 44px" text="$l10n_wc_about_tab_staff"/>
 
+            <!-- ============================================================ -->
+            <!-- PANEL 1 — CORE: billing strategy, timing, save persistence    -->
+            <!-- ============================================================ -->
+            <GuiElement id="paneCore" position="0px -40px" size="1040px 520px">
+
+                <!-- LEFT: how it works body text -->
+                <ThreePartBitmap profile="fs25_primaryMenuContainerBg" width="580px" height="500px" position="0px 0px">
+                    <Bitmap profile="fs25_menuContainerArrow"/>
+                    <GuiElement profile="fs25_subCategoryContainer" width="540px">
+                        <Text profile="WC_SectionTitle" position="10px -10px" text="$l10n_wc_section_how_it_works"/>
+                        <ThreePartBitmap profile="fs25_lineSeparatorTop" position="5px -34px" width="520px"/>
+                        <Text profile="WC_BodyText" position="10px -54px" size="520px 440px" textMaxNumLines="22" text="$l10n_wc_about_core_body"/>
+                    </GuiElement>
+                </ThreePartBitmap>
+
+                <Bitmap profile="fs25_settingsTooltipSeparator" position="596px -20px"/>
+
+                <!-- RIGHT: payment timing + version -->
+                <GuiElement position="614px 10px" width="420px" height="500px">
+                    <Text profile="WC_SectionTitle" position="0px -10px" text="$l10n_wc_section_payment"/>
+                    <ThreePartBitmap profile="fs25_lineSeparatorTop" position="0px -34px" width="400px"/>
+
+                    <BoxLayout profile="WC_RowBoxH" position="0px -54px" width="400px">
+                        <Text profile="WC_RowLabel" text="$l10n_wc_label_pay_interval" width="200px"/>
+                        <Text profile="WC_RowValue" id="txtPayInterval" width="190px"/>
+                    </BoxLayout>
+
+                    <Text profile="WC_BodyText" position="0px -90px" size="400px 160px" textMaxNumLines="6" text="$l10n_wc_about_payment_note"/>
+
+                    <ThreePartBitmap profile="fs25_lineSeparatorTop" position="0px -260px" width="400px"/>
+                    <Text profile="WC_BigStatLabel" position="0px -280px" text="$l10n_wc_label_version"/>
+                    <Text profile="WC_RowValue" id="txtVersion" position="0px -300px" width="400px"/>
                 </GuiElement>
-            </ThreePartBitmap>
 
-            <!-- Vertical separator -->
-            <Bitmap profile="fs25_settingsTooltipSeparator" position="596px 0px"/>
+            </GuiElement>
 
-            <!-- RIGHT: Quick reference — wage table + payment info -->
-            <GuiElement position="614px 30px" width="420px" height="560px">
+            <!-- ============================================================ -->
+            <!-- PANEL 2 — FORMULAS: Hourly vs Hectare + live configuration    -->
+            <!-- ============================================================ -->
+            <GuiElement id="paneFormulas" position="0px -40px" size="1040px 520px">
 
-                <Text profile="WC_SectionTitle" position="0px -10px" text="$l10n_wc_section_wage_level"/>
-                <ThreePartBitmap profile="fs25_lineSeparatorTop" position="0px -34px" width="400px"/>
+                <!-- LEFT: how wages are calculated -->
+                <ThreePartBitmap profile="fs25_primaryMenuContainerBg" width="580px" height="500px" position="0px 0px">
+                    <Bitmap profile="fs25_menuContainerArrow"/>
+                    <GuiElement profile="fs25_subCategoryContainer" width="540px">
+                        <Text profile="WC_SectionTitle" position="10px -10px" text="$l10n_wc_about_tab_formulas"/>
+                        <ThreePartBitmap profile="fs25_lineSeparatorTop" position="5px -34px" width="520px"/>
+                        <Text profile="WC_BodyText" position="10px -54px" size="520px 440px" textMaxNumLines="22" text="$l10n_wc_about_formulas_body"/>
+                    </GuiElement>
+                </ThreePartBitmap>
 
-                <!-- wc_diff_N already includes the price: "Low ($15/h)" etc. -->
-                <Text profile="WC_RowLabel" position="0px -54px" width="400px" text="$l10n_wc_diff_1"/>
-                <Text profile="WC_RowLabel" position="0px -82px" width="400px" text="$l10n_wc_diff_2"/>
-                <Text profile="WC_RowLabel" position="0px -110px" width="400px" text="$l10n_wc_diff_3"/>
+                <Bitmap profile="fs25_settingsTooltipSeparator" position="596px -20px"/>
 
-                <ThreePartBitmap profile="fs25_lineSeparatorTop" position="0px -144px" width="400px"/>
-                <Text profile="WC_SectionTitle" position="0px -164px" text="$l10n_wc_section_payment"/>
-                <ThreePartBitmap profile="fs25_lineSeparatorTop" position="0px -188px" width="400px"/>
+                <!-- RIGHT: live configuration (bound to Settings) + wage tiers -->
+                <GuiElement position="614px 10px" width="420px" height="500px">
+                    <Text profile="WC_SectionTitle" position="0px -10px" text="$l10n_wc_section_effective"/>
+                    <ThreePartBitmap profile="fs25_lineSeparatorTop" position="0px -34px" width="400px"/>
 
-                <BoxLayout profile="WC_RowBoxH" position="0px -206px" width="400px">
-                    <Text profile="WC_RowLabel" text="$l10n_wc_label_pay_interval" width="200px"/>
-                    <Text profile="WC_RowValue" id="txtPayInterval" width="190px"/>
-                </BoxLayout>
+                    <Text profile="WC_BigStat" id="txtEffRate" position="0px -58px"/>
+                    <Text profile="WC_BigStatLabel" id="txtRateLabel" position="0px -104px"/>
 
-                <Text profile="WC_BodyText" position="0px -240px" size="400px 120px" textMaxNumLines="5" text="$l10n_wc_about_payment_note"/>
+                    <BoxLayout profile="WC_RowBoxH" position="0px -150px" width="400px">
+                        <Text profile="WC_RowLabel" text="$l10n_wc_section_cost_mode" width="200px"/>
+                        <Text profile="WC_RowValue" id="txtCostMode" width="190px"/>
+                    </BoxLayout>
 
-                <ThreePartBitmap profile="fs25_lineSeparatorTop" position="0px -370px" width="400px"/>
+                    <ThreePartBitmap profile="fs25_lineSeparatorTop" position="0px -190px" width="400px"/>
+                    <Text profile="WC_SectionTitle" position="0px -210px" text="$l10n_wc_section_wage_level"/>
+                    <ThreePartBitmap profile="fs25_lineSeparatorTop" position="0px -234px" width="400px"/>
 
-                <Text profile="WC_BigStatLabel" position="0px -390px" text="$l10n_wc_label_version"/>
-                <Text profile="WC_RowValue" id="txtVersion" position="0px -410px" width="400px"/>
+                    <Text profile="WC_RowLabel" position="0px -254px" width="400px" text="$l10n_wc_diff_1"/>
+                    <Text profile="WC_RowLabel" position="0px -282px" width="400px" text="$l10n_wc_diff_2"/>
+                    <Text profile="WC_RowLabel" position="0px -310px" width="400px" text="$l10n_wc_diff_3"/>
+                </GuiElement>
+
+            </GuiElement>
+
+            <!-- ============================================================ -->
+            <!-- PANEL 3 — PRO-STAFF: XP, fatigue, mastery overview            -->
+            <!-- ============================================================ -->
+            <GuiElement id="paneStaff" position="0px -40px" size="1040px 520px">
+
+                <ThreePartBitmap profile="fs25_primaryMenuContainerBg" width="1020px" height="500px" position="0px 0px">
+                    <Bitmap profile="fs25_menuContainerArrow"/>
+                    <GuiElement profile="fs25_subCategoryContainer" width="980px">
+                        <Text profile="WC_SectionTitle" position="10px -10px" text="$l10n_wc_about_tab_staff"/>
+                        <ThreePartBitmap profile="fs25_lineSeparatorTop" position="5px -34px" width="960px"/>
+                        <Text profile="WC_BodyText" position="10px -54px" size="960px 440px" textMaxNumLines="22" text="$l10n_wc_about_staff_body"/>
+                    </GuiElement>
+                </ThreePartBitmap>
 
             </GuiElement>
 


### PR DESCRIPTION
About tab refactored from text blobs into real styled section headers, and the Pro-Staff tab is now two columns (Experience/Mastery left, Fatigue/Tips right).