### PR TITLE
Input Convention: clear default bindings

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -19,6 +19,7 @@
 - [x] Monthly-salary double-charge gremlin (100d3c6): monthly-salary mode no longer double-charges wages. DONE.
 - [x] Legendary tier (fast-track F1): 4th tier with the LOCKED values. DONE (d20da2f), shipped v2.2.2.2.
 - [!] ProStaff modifiers (Point 5): read getWageModifier / getFatigueRecoveryBonus / getFatigueMitigation in calculateLaborCost and fatigue recovery; neutral 1.0 when ProStaff absent. Blocked on the ProStaff build (brief pulled, under re-review).
+- [x] 2026-07-26 bug sweep: WC-001 / WC-002 / WC-003 fixed and merged to main.
 
 ## Mid-term (this season)
 - [x] Bedrock migration: StateLedger (4328920), NetworkSync v2 (c179141), MasterHUD roster panel (4b10bd5), SettingsHub (ff35ed0). DONE, shipped v2.2.2.2, addMoney hook intact. (ESC WorkerSettingsUI removal still open.)

--- a/TODO.md
+++ b/TODO.md
@@ -16,6 +16,7 @@
 - [x] Design flag resolved: real-time billing replaced by per-in-game-day billing, coherent with the onDayChange cost systems. DONE (0c808d1).
 - [x] G2: the addMoney fallback heuristic tightened. DONE (8c70f45).
 - [x] Legendary surcharge-DISPLAY fix: the roster estimate no longer surcharges Legendary workers (matches the authoritative charge). DONE (b84728f), shipped in v2.2.2.2.
+- [x] WC-001 / WC-002 / WC-003: additional WorkerCosts bugs fixed in 2026-07-26 bug sweep, merged to main.
 
 ## Features / enhancements
 - [~] Legendary tier DONE (d20da2f). The 6-function companion read API is partial: getWorkersForFarm shipped (90ce2e1); the rest pending the DairyCore/ProStaff builds.

--- a/modDesc.xml
+++ b/modDesc.xml
@@ -1590,9 +1590,7 @@ Brug Nulstil for at gendanne alle indstillinger til standardværdierne.</da>
     </l10n>
 
     <inputBinding>
-        <actionBinding action="WC_OPEN_ROSTER">
-            <binding device="KB_MOUSE_DEFAULT" input="KEY_lalt KEY_h" />
-        </actionBinding>
+        <actionBinding action="WC_OPEN_ROSTER" />
     </inputBinding>
 
 </modDesc>


### PR DESCRIPTION
## Changes

### Input Convention (B2)
- Cleared default binding: WC_OPEN_ROSTER (lalt+h)
- Rule 1 compliant: no default key binding shipped