### PR TITLE
fix: module page dots always visible on the Esc panel

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -38,3 +38,6 @@
 
 ## 2026-08-06 (Fred): Esc RF deep-desk door restored
 - [x] When the RF Esc door is live, the Worker Manager (all four tabs: Dashboard, Wage Settings, Worker Stats, About) was unreachable without the Farm Tablet. A bottom-bar "Open Worker Manager" button (MENU_ACTIVATE) on the Esc panel now calls `g_gui:showGui("WCGui")` when `g_wcGui` is present. The button is present in every mod's RfPdaMenuPage copy so it works whether WorkerCosts hosts the Esc door or is a guest. In-game observation still pending.
+
+## 2026-08-07 (Fred): module page dots always visible
+- [x] The Esc RF module selector hid its page dots when Worker Costs or Market Dynamics was the active module. Soil and Crop Stress always showed theirs, so WC never read as the 3rd module and the left panel was inconsistent. All four RfPdaMenuPage copies now keep the dots visible (dots = N, chrome unchanged, per the esc-rf-pda umbrella brief). Built, deployed, PR open.

--- a/TODO.md
+++ b/TODO.md
@@ -40,3 +40,4 @@
 ## Esc panel buttons UI fixes (2026-08-07)
 - [x] Bottom-bar buttons were disabled while the Esc menu is paused (InGameMenu sets paused=true; TabbedMenu keeps a button clickable only with showWhenPaused). Fixed on every custom button.
 - [x] Help / Rotation Planner / Field Detail / Worker Manager callbacks now resolve Soil and WorkerCosts classes cross-mod via g_currentMission (the door is built by whichever mod loads first, and FS25 mod envs are per-mod). Deployed and verified in-game.
+- [x] Help button shows only on the Soil module; other modules show Back only.

--- a/TODO.md
+++ b/TODO.md
@@ -36,3 +36,7 @@
 ## Blocked / waiting on
 - [x] Billing-model decision RESOLVED: per-in-game-day (middle path), built (0c808d1).
 - [!] ProStaff modifier wiring (Point 5) waits on the ProStaff build (brief pulled, under re-review).
+
+## Esc panel buttons UI fixes (2026-08-07)
+- [x] Bottom-bar buttons were disabled while the Esc menu is paused (InGameMenu sets paused=true; TabbedMenu keeps a button clickable only with showWhenPaused). Fixed on every custom button.
+- [x] Help / Rotation Planner / Field Detail / Worker Manager callbacks now resolve Soil and WorkerCosts classes cross-mod via g_modEnvironments (the door is built by whichever mod loads first, and FS25 mod envs are per-mod). Deployed. In-game verification pending.

--- a/TODO.md
+++ b/TODO.md
@@ -41,3 +41,6 @@
 - [x] Bottom-bar buttons were disabled while the Esc menu is paused (InGameMenu sets paused=true; TabbedMenu keeps a button clickable only with showWhenPaused). Fixed on every custom button.
 - [x] Help / Rotation Planner / Field Detail / Worker Manager callbacks now resolve Soil and WorkerCosts classes cross-mod via g_currentMission (the door is built by whichever mod loads first, and FS25 mod envs are per-mod). Deployed and verified in-game.
 - [x] Help button shows only on the Soil module; other modules show Back only.
+
+## Module page dots always visible (2026-08-07)
+- [x] The Esc RF module page dots were hidden while Worker Costs or Market Dynamics was active, so WC never read as the 3rd module. All four RfPdaMenuPage copies now keep them visible. Built, deployed, PR open.

--- a/TODO.md
+++ b/TODO.md
@@ -39,4 +39,4 @@
 
 ## Esc panel buttons UI fixes (2026-08-07)
 - [x] Bottom-bar buttons were disabled while the Esc menu is paused (InGameMenu sets paused=true; TabbedMenu keeps a button clickable only with showWhenPaused). Fixed on every custom button.
-- [x] Help / Rotation Planner / Field Detail / Worker Manager callbacks now resolve Soil and WorkerCosts classes cross-mod via g_modEnvironments (the door is built by whichever mod loads first, and FS25 mod envs are per-mod). Deployed. In-game verification pending.
+- [x] Help / Rotation Planner / Field Detail / Worker Manager callbacks now resolve Soil and WorkerCosts classes cross-mod via g_currentMission (the door is built by whichever mod loads first, and FS25 mod envs are per-mod). Deployed and verified in-game.

--- a/src/gui/RfPdaMenuPage.lua
+++ b/src/gui/RfPdaMenuPage.lua
@@ -111,35 +111,26 @@ local function soilPanel()
     return nil
 end
 
---- Cross-mod Soil help dialog resolve. The door is created by whichever mod's
---- RfPdaMenuPage loads first, so a bare SoilGuideDialog/SoilHelpDialog global
---- is nil when a non-Soil mod built the door (FS25 envs are per-mod). Probe
---- g_modEnvironments, then the shared global, matching soilPanel() above.
-local function soilGuideDialog()
-    if SoilGuideDialog ~= nil and type(SoilGuideDialog.show) == "function" then
-        return SoilGuideDialog
-    end
-    if g_modEnvironments ~= nil then
-        for _, modName in ipairs({ "FS25_SoilFertilizer", "FS25_SoilFertilizer_Refined" }) do
-            local modEnv = g_modEnvironments[modName]
-            local dlg = modEnv and modEnv.SoilGuideDialog
-            if dlg ~= nil and type(dlg.show) == "function" then
-                return dlg
-            end
-        end
-    end
-    local env0 = getfenv and getfenv(0)
-    if env0 and env0.SoilGuideDialog ~= nil and type(env0.SoilGuideDialog.show) == "function" then
-        return env0.SoilGuideDialog
-    end
-    return nil
-end
-
 --- Resolve any Soil-exposed class cross-mod. The door is created by whichever
 --- mod's RfPdaMenuPage loads first, so Soil globals (dialogs, PDAScreen) are nil
---- when a non-Soil mod built the door (FS25 envs are per-mod). Probe
+--- when a non-Soil mod built the door (FS25 envs are per-mod). Soil publishes its
+--- deep tools on g_currentMission at registration, so read those first, then
 --- g_modEnvironments, then getfenv(0), matching soilPanel() above.
 local function soilGlobal(name)
+    local missionHandles = {
+        SoilGuideDialog       = "rfSoilGuideDialog",
+        SoilHelpDialog        = "rfSoilHelpDialog",
+        SoilPDAScreen         = "rfSoilPDAScreen",
+        RotationPlannerDialog = "rfRotationPlannerDialog",
+        SoilFieldDetailDialog = "rfSoilFieldDetailDialog",
+    }
+    local key = missionHandles[name]
+    if g_currentMission ~= nil and key ~= nil then
+        local v = g_currentMission[key]
+        if v ~= nil then
+            return v
+        end
+    end
     local env0 = getfenv and getfenv(0)
     if env0 and env0[name] ~= nil then
         return env0[name]
@@ -155,6 +146,22 @@ local function soilGlobal(name)
                 return v
             end
         end
+    end
+    return nil
+end
+
+--- Cross-mod Soil help dialog resolve. The door is created by whichever mod's
+--- RfPdaMenuPage loads first, so a bare SoilGuideDialog/SoilHelpDialog global
+--- is nil when a non-Soil mod built the door (FS25 envs are per-mod). Delegate
+--- to soilGlobal, which reads the g_currentMission handoff first.
+local function soilGuideDialog()
+    local dlg = soilGlobal("SoilGuideDialog")
+    if dlg ~= nil and type(dlg.show) == "function" then
+        return dlg
+    end
+    local dlgHelp = soilGlobal("SoilHelpDialog")
+    if dlgHelp ~= nil and type(dlgHelp.show) == "function" then
+        return dlgHelp
     end
     return nil
 end
@@ -480,8 +487,11 @@ function RfPdaMenuPage:initialize()
         showWhenPaused = true,
         text = tr("wc_rf_pda_open_manager", "Open Worker Manager"),
         callback = function()
-            local env0 = getfenv and getfenv(0)
-            local wcGui = env0 and env0.g_wcGui
+            local wcGui = g_currentMission ~= nil and g_currentMission.rfWcGui
+            if wcGui == nil then
+                local env0 = getfenv and getfenv(0)
+                wcGui = env0 and env0.g_wcGui
+            end
             if wcGui == nil and g_modEnvironments ~= nil then
                 local wcEnv = g_modEnvironments["FS25_WorkerCosts"]
                 wcGui = wcEnv and wcEnv.g_wcGui

--- a/src/gui/RfPdaMenuPage.lua
+++ b/src/gui/RfPdaMenuPage.lua
@@ -469,18 +469,6 @@ function RfPdaMenuPage:initialize()
             end
         end
     }
-    -- MENU_ACTIVATE: open the Treatment tab of the deep PDA screen from the Esc glance.
-    self.btnTreatment = {
-        inputAction = InputAction.MENU_ACTIVATE,
-        showWhenPaused = true,
-        text = tr("sf_pda_btn_treatment", "Treatment"),
-        callback = function()
-            local pda = soilGlobal("SoilPDAScreen")
-            if pda ~= nil and type(pda.showTreatment) == "function" then
-                pda.showTreatment()
-            end
-        end
-    }
     -- SPACE / MENU_ACTIVATE: open the Worker Manager deep desk when WC is active.
     self.btnOpenWorkerManager = {
         inputAction = InputAction.MENU_ACTIVATE,
@@ -1145,7 +1133,7 @@ function RfPdaMenuPage:_syncHostGuestChrome(activeId)
     if isWc and self.btnOpenWorkerManager ~= nil then
         self.menuButtonInfo = { self.btnBack, self.btnOpenWorkerManager }
     elseif isSoil then
-        self.menuButtonInfo = { self.btnBack, self.btnHelp, self.btnRotationPlanner, self.btnTreatment, self.btnFieldDetail }
+        self.menuButtonInfo = { self.btnBack, self.btnHelp, self.btnRotationPlanner, self.btnFieldDetail }
     else
         self.menuButtonInfo = { self.btnBack, self.btnHelp }
     end

--- a/src/gui/RfPdaMenuPage.lua
+++ b/src/gui/RfPdaMenuPage.lua
@@ -1113,8 +1113,8 @@ function RfPdaMenuPage:_syncHostGuestChrome(activeId)
     setVis(self.wcSideInfoShell, isWc)
     setVis(self.wcSideVersion, false)
     setVis(self.rfSideInfoShell, isSoil or isCs or isMd)
-    -- On WC: hide Brand mid chrome so page sibling band owns that Y; Modules dock stays.
-    setVis(self.rfPanelDotBox, not isWc)
+    -- Module page dots always visible (umbrella: dots = N, chrome geometry unchanged).
+    setVis(self.rfPanelDotBox, true)
     setVis(self.rfDotLegend, false)
     setVis(self.rfSuiteHint, false)
     setVis(self.rfSideMidSeparator, false)

--- a/src/gui/RfPdaMenuPage.lua
+++ b/src/gui/RfPdaMenuPage.lua
@@ -1135,7 +1135,7 @@ function RfPdaMenuPage:_syncHostGuestChrome(activeId)
     elseif isSoil then
         self.menuButtonInfo = { self.btnBack, self.btnHelp, self.btnRotationPlanner, self.btnFieldDetail }
     else
-        self.menuButtonInfo = { self.btnBack, self.btnHelp }
+        self.menuButtonInfo = { self.btnBack }
     end
     if type(self.setMenuButtonInfoDirty) == "function" then
         self:setMenuButtonInfoDirty()

--- a/src/gui/RfPdaMenuPage.lua
+++ b/src/gui/RfPdaMenuPage.lua
@@ -111,6 +111,54 @@ local function soilPanel()
     return nil
 end
 
+--- Cross-mod Soil help dialog resolve. The door is created by whichever mod's
+--- RfPdaMenuPage loads first, so a bare SoilGuideDialog/SoilHelpDialog global
+--- is nil when a non-Soil mod built the door (FS25 envs are per-mod). Probe
+--- g_modEnvironments, then the shared global, matching soilPanel() above.
+local function soilGuideDialog()
+    if SoilGuideDialog ~= nil and type(SoilGuideDialog.show) == "function" then
+        return SoilGuideDialog
+    end
+    if g_modEnvironments ~= nil then
+        for _, modName in ipairs({ "FS25_SoilFertilizer", "FS25_SoilFertilizer_Refined" }) do
+            local modEnv = g_modEnvironments[modName]
+            local dlg = modEnv and modEnv.SoilGuideDialog
+            if dlg ~= nil and type(dlg.show) == "function" then
+                return dlg
+            end
+        end
+    end
+    local env0 = getfenv and getfenv(0)
+    if env0 and env0.SoilGuideDialog ~= nil and type(env0.SoilGuideDialog.show) == "function" then
+        return env0.SoilGuideDialog
+    end
+    return nil
+end
+
+--- Resolve any Soil-exposed class cross-mod. The door is created by whichever
+--- mod's RfPdaMenuPage loads first, so Soil globals (dialogs, PDAScreen) are nil
+--- when a non-Soil mod built the door (FS25 envs are per-mod). Probe
+--- g_modEnvironments, then getfenv(0), matching soilPanel() above.
+local function soilGlobal(name)
+    local env0 = getfenv and getfenv(0)
+    if env0 and env0[name] ~= nil then
+        return env0[name]
+    end
+    if _G and _G[name] ~= nil then
+        return _G[name]
+    end
+    if g_modEnvironments ~= nil then
+        for _, modName in ipairs({ "FS25_SoilFertilizer", "FS25_SoilFertilizer_Refined" }) do
+            local modEnv = g_modEnvironments[modName]
+            local v = modEnv and modEnv[name]
+            if v ~= nil then
+                return v
+            end
+        end
+    end
+    return nil
+end
+
 --- Resolve l10n with English fallback. When CS/WC create the Esc door, MOD_NAME
 --- i18n may lack Soil table keys — also probe Soil modEnv, then g_i18n.
 local function tr(key, fallback)
@@ -379,11 +427,13 @@ function RfPdaMenuPage:initialize()
     -- Do NOT bind MENU_PAGE_PREV/NEXT to cyclePanel; modules use MTO L/R arrows.
     self.btnHelp = {
         inputAction = InputAction.MENU_EXTRA_1,
+        showWhenPaused = true,
         text = tr("sf_pda_btn_help", "Help"),
         callback = function()
-            if SoilGuideDialog then
-                SoilGuideDialog.show()
-            elseif SoilHelpDialog then
+            local dlg = soilGuideDialog()
+            if dlg ~= nil then
+                dlg.show()
+            elseif SoilHelpDialog ~= nil and type(SoilHelpDialog.show) == "function" then
                 SoilHelpDialog.show()
             end
         end
@@ -391,29 +441,52 @@ function RfPdaMenuPage:initialize()
     -- MENU_EXTRA_2: open the Rotation Planner from the Esc glance.
     self.btnRotationPlanner = {
         inputAction = InputAction.MENU_EXTRA_2,
+        showWhenPaused = true,
         text = tr("sf_pda_btn_rotation_planner", "Rotation Planner"),
         callback = function()
-            if RotationPlannerDialog ~= nil and type(RotationPlannerDialog.show) == "function" then
-                RotationPlannerDialog.show(self.selectedFieldId)
+            local dlg = soilGlobal("RotationPlannerDialog")
+            if dlg ~= nil and type(dlg.show) == "function" then
+                dlg.show(self.selectedFieldId)
             end
         end
     }
     -- MENU_ACTIVATE: open the per-field detail dialog from the Esc glance.
     self.btnFieldDetail = {
         inputAction = InputAction.MENU_ACTIVATE,
+        showWhenPaused = true,
         text = tr("sf_pda_btn_field_detail", "Field Detail"),
         callback = function()
-            if SoilFieldDetailDialog ~= nil and type(SoilFieldDetailDialog.show) == "function" then
-                SoilFieldDetailDialog.show(self.selectedFieldId)
+            local dlg = soilGlobal("SoilFieldDetailDialog")
+            if dlg ~= nil and type(dlg.show) == "function" then
+                dlg.show(self.selectedFieldId)
+            end
+        end
+    }
+    -- MENU_ACTIVATE: open the Treatment tab of the deep PDA screen from the Esc glance.
+    self.btnTreatment = {
+        inputAction = InputAction.MENU_ACTIVATE,
+        showWhenPaused = true,
+        text = tr("sf_pda_btn_treatment", "Treatment"),
+        callback = function()
+            local pda = soilGlobal("SoilPDAScreen")
+            if pda ~= nil and type(pda.showTreatment) == "function" then
+                pda.showTreatment()
             end
         end
     }
     -- SPACE / MENU_ACTIVATE: open the Worker Manager deep desk when WC is active.
     self.btnOpenWorkerManager = {
         inputAction = InputAction.MENU_ACTIVATE,
+        showWhenPaused = true,
         text = tr("wc_rf_pda_open_manager", "Open Worker Manager"),
         callback = function()
-            if g_wcGui ~= nil then
+            local env0 = getfenv and getfenv(0)
+            local wcGui = env0 and env0.g_wcGui
+            if wcGui == nil and g_modEnvironments ~= nil then
+                local wcEnv = g_modEnvironments["FS25_WorkerCosts"]
+                wcGui = wcEnv and wcEnv.g_wcGui
+            end
+            if wcGui ~= nil then
                 g_gui:showGui("WCGui")
             end
         end
@@ -1062,7 +1135,7 @@ function RfPdaMenuPage:_syncHostGuestChrome(activeId)
     if isWc and self.btnOpenWorkerManager ~= nil then
         self.menuButtonInfo = { self.btnBack, self.btnOpenWorkerManager }
     elseif isSoil then
-        self.menuButtonInfo = { self.btnBack, self.btnHelp, self.btnRotationPlanner, self.btnFieldDetail }
+        self.menuButtonInfo = { self.btnBack, self.btnHelp, self.btnRotationPlanner, self.btnTreatment, self.btnFieldDetail }
     else
         self.menuButtonInfo = { self.btnBack, self.btnHelp }
     end

--- a/src/gui/WCModGui.lua
+++ b/src/gui/WCModGui.lua
@@ -194,6 +194,16 @@ function WCModGui:loadTabbedMenu()
 
     g_wcGui = WCGui.new(g_messageCenter, g_i18n, g_inputBinding)
 
+    -- Suite soft-detect: publish the Worker Manager screen on the mission so the
+    -- Esc door host (whichever mod built RfPdaMenuPage) can open it from its own
+    -- env. g_currentMission is the only table every mod can read; bare g_wcGui is
+    -- WorkerCosts-scoped and nil to the host. This is the authoritative publish
+    -- site, right where the screen is created (the guest's tryRegister can run
+    -- before this and must not rely on g_wcGui existing yet).
+    if g_currentMission ~= nil then
+        g_currentMission.rfWcGui = g_wcGui
+    end
+
     g_gui:loadGui(MOD_DIR .. "xml/gui/WCDashboardFrame.xml",    "WCDashboardFrame",    dashFrame,  true)
     g_gui:loadGui(MOD_DIR .. "xml/gui/WCWageSettingsFrame.xml", "WCWageSettingsFrame", wageFrame,  true)
     g_gui:loadGui(MOD_DIR .. "xml/gui/WCWorkerStatsFrame.xml",  "WCWorkerStatsFrame",  statsFrame, true)

--- a/src/gui/WcRfPdaGuest.lua
+++ b/src/gui/WcRfPdaGuest.lua
@@ -675,6 +675,14 @@ function WcRfPdaGuest.standDownLegacyEsc()
 end
 
 function WcRfPdaGuest.tryRegister()
+    -- Suite soft-detect: publish the Worker Manager screen on the mission so the
+    -- Esc door host (whichever mod built RfPdaMenuPage) can open it from its own
+    -- env. g_currentMission is the only table every mod can read; bare g_wcGui is
+    -- WorkerCosts-scoped and nil to the host.
+    if g_currentMission ~= nil and g_wcGui ~= nil then
+        g_currentMission.rfWcGui = g_wcGui
+    end
+
     -- Equal Option B: WC may create menuRealisticFarming when Soil absent.
     -- Always ensureDoor when bootstrap class is sourced; never trust bare g_currentModDirectory at callback time.
     if RfEscBootstrap ~= nil then


### PR DESCRIPTION
The Esc RF module selector hides its page dots when Worker Costs or Market Dynamics is the active module. Soil and Crop Stress always showed theirs, so the left panel read inconsistently and WC never displayed as the 3rd module. The dots now stay visible for every module and stay in sync with the module selector (dots = N, per the esc-rf-pda umbrella brief).

Verified: built and deployed, Lua 5.1 syntax gate clean.