### PR TITLE
F155: Esc RF button translations for language testing

### DIFF
--- a/build.py
+++ b/build.py
@@ -31,6 +31,7 @@ INCLUDE = [
     "README.md",
     "src",
     "xml",
+    "translations",
 ]
 
 

--- a/modDesc.xml
+++ b/modDesc.xml
@@ -39,7 +39,7 @@
         <action name="WC_OPEN_ROSTER" category="ONFOOT" />
     </actions>
 
-    <l10n>
+    <l10n filenamePrefix="translations/translation" defaultLanguage="en">
         <text name="wc_section">
             <en>Worker Costs Mod</en>
             <de>Arbeiterkosten-Mod</de>
@@ -1691,7 +1691,91 @@ Brug Nulstil for at gendanne alle indstillinger til standardvÃƒÂ¦rdierne.</d
             <ru>[EN] No field data recorded yet.</ru>
             <uk>[EN] No field data recorded yet.</uk>
         </text>
-    </l10n>
+                <text name="wc_rf_pda_open_manager">
+            <br>Abrir gerenciador de trabalhadores</br>
+            <cz>Otevřít správce pracovníků</cz>
+            <da>Åbn medarbejderstyring</da>
+            <de>Arbeitermanager öffnen</de>
+            <en>Open Worker Manager</en>
+            <es>Abrir gestor de trabajadores</es>
+            <fr>Ouvrir le gestionnaire d'ouvriers</fr>
+            <it>Apri gestore operai</it>
+            <pl>Otwórz menedżera pracowników</pl>
+            <ru>Открыть менеджер работников</ru>
+            <uk>Відкрити менеджер працівників</uk>
+            <nl>Werkersbeheer openen</nl>
+            <pt>Abrir gestor de trabalhadores</pt>
+            <sv>Öppna arbetshanteraren</sv>
+            <no>Åpne arbeiderbehandler</no>
+            <fi>Avaa työntekijähallinta</fi>
+            <hu>Dolgozókezelő megnyitása</hu>
+            <ro>Deschide managerul de muncitori</ro>
+            <tr>İşçi yöneticisini aç</tr>
+            <jp>作業員マネージャーを開く</jp>
+            <kr>작업자 관리자 열기</kr>
+            <ct>開啟工人管理員</ct>
+            <fc>Ouvrir le gestionnaire d'ouvriers</fc>
+            <ea>Abrir gestor de trabajadores</ea>
+            <id>Buka manajer pekerja</id>
+            <vi>Mở trình quản lý công nhân</vi>
+        </text>
+        <text name="sf_pda_btn_rotation_planner">
+            <br>Planejador de rotação</br>
+            <cz>Plánovač osevního postupu</cz>
+            <da>Rotationsplanlægger</da>
+            <de>Fruchtfolgeplaner</de>
+            <en>Rotation Planner</en>
+            <es>Planificador de rotación</es>
+            <fr>Planificateur de rotation</fr>
+            <it>Pianificatore rotazioni</it>
+            <pl>Planer płodozmianu</pl>
+            <ru>Планировщик севооборота</ru>
+            <uk>Планувальник сівозміни</uk>
+            <nl>Rotatieplanner</nl>
+            <pt>Planeador de rotação</pt>
+            <sv>Växtföljdsplanerare</sv>
+            <no>Rotasjonsplanlegger</no>
+            <fi>Viljelykiertosuunnittelija</fi>
+            <hu>Vetésforgó-tervező</hu>
+            <ro>Planificator de rotație</ro>
+            <tr>Ekim nöbeti planlayıcı</tr>
+            <jp>輪作プランナー</jp>
+            <kr>윤작 계획기</kr>
+            <ct>輪作規劃</ct>
+            <fc>Planificateur de rotation</fc>
+            <ea>Planificador de rotación</ea>
+            <id>Perencana rotasi</id>
+            <vi>Lập kế hoạch luân canh</vi>
+        </text>
+        <text name="sf_pda_btn_field_detail">
+            <br>Detalhe do campo</br>
+            <cz>Detail pole</cz>
+            <da>Markdetaljer</da>
+            <de>Felddetails</de>
+            <en>Field Detail</en>
+            <es>Detalle del campo</es>
+            <fr>Détail du champ</fr>
+            <it>Dettaglio campo</it>
+            <pl>Szczegóły pola</pl>
+            <ru>Сведения о поле</ru>
+            <uk>Деталі поля</uk>
+            <nl>Veldgegevens</nl>
+            <pt>Detalhe do campo</pt>
+            <sv>Fältdetaljer</sv>
+            <no>Feltdetaljer</no>
+            <fi>Pellon tiedot</fi>
+            <hu>Táblarészletek</hu>
+            <ro>Detaliu câmp</ro>
+            <tr>Tarla detayı</tr>
+            <jp>畑の詳細</jp>
+            <kr>밯 상세</kr>
+            <ct>田地詳情</ct>
+            <fc>Détail du champ</fc>
+            <ea>Detalle del campo</ea>
+            <id>Detail lahan</id>
+            <vi>Chi tiết thửa ruộng</vi>
+        </text>
+</l10n>
 
     <inputBinding>
         <actionBinding action="WC_OPEN_ROSTER" />

--- a/translations/translation_br.xml
+++ b/translations/translation_br.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<l10n>
+    <texts>
+        <!-- BUILD 11:27 F155 Esc RF button labels -->
+        <text name="wc_rf_pda_open_manager" text="Abrir gerenciador de trabalhadores" />
+        <text name="sf_pda_btn_rotation_planner" text="Planejador de rotação" />
+        <text name="sf_pda_btn_field_detail" text="Detalhe do campo" />
+    </texts>
+</l10n>

--- a/translations/translation_ct.xml
+++ b/translations/translation_ct.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<l10n>
+    <texts>
+        <!-- BUILD 11:27 F155 Esc RF button labels -->
+        <text name="wc_rf_pda_open_manager" text="開啟工人管理員" />
+        <text name="sf_pda_btn_rotation_planner" text="輪作規劃" />
+        <text name="sf_pda_btn_field_detail" text="田地詳情" />
+    </texts>
+</l10n>

--- a/translations/translation_cz.xml
+++ b/translations/translation_cz.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<l10n>
+    <texts>
+        <!-- BUILD 11:27 F155 Esc RF button labels -->
+        <text name="wc_rf_pda_open_manager" text="Otevřít správce pracovníků" />
+        <text name="sf_pda_btn_rotation_planner" text="Plánovač osevního postupu" />
+        <text name="sf_pda_btn_field_detail" text="Detail pole" />
+    </texts>
+</l10n>

--- a/translations/translation_da.xml
+++ b/translations/translation_da.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<l10n>
+    <texts>
+        <!-- BUILD 11:27 F155 Esc RF button labels -->
+        <text name="wc_rf_pda_open_manager" text="Åbn medarbejderstyring" />
+        <text name="sf_pda_btn_rotation_planner" text="Rotationsplanlægger" />
+        <text name="sf_pda_btn_field_detail" text="Markdetaljer" />
+    </texts>
+</l10n>

--- a/translations/translation_de.xml
+++ b/translations/translation_de.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<l10n>
+    <texts>
+        <!-- BUILD 11:27 F155 Esc RF button labels -->
+        <text name="wc_rf_pda_open_manager" text="Arbeitermanager öffnen" />
+        <text name="sf_pda_btn_rotation_planner" text="Fruchtfolgeplaner" />
+        <text name="sf_pda_btn_field_detail" text="Felddetails" />
+    </texts>
+</l10n>

--- a/translations/translation_ea.xml
+++ b/translations/translation_ea.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<l10n>
+    <texts>
+        <!-- BUILD 11:27 F155 Esc RF button labels -->
+        <text name="wc_rf_pda_open_manager" text="Abrir gestor de trabajadores" />
+        <text name="sf_pda_btn_rotation_planner" text="Planificador de rotación" />
+        <text name="sf_pda_btn_field_detail" text="Detalle del campo" />
+    </texts>
+</l10n>

--- a/translations/translation_en.xml
+++ b/translations/translation_en.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<l10n>
+    <texts>
+        <!-- BUILD 11:27 F155 Esc RF button labels -->
+        <text name="wc_rf_pda_open_manager" text="Open Worker Manager" />
+        <text name="sf_pda_btn_rotation_planner" text="Rotation Planner" />
+        <text name="sf_pda_btn_field_detail" text="Field Detail" />
+    </texts>
+</l10n>

--- a/translations/translation_es.xml
+++ b/translations/translation_es.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<l10n>
+    <texts>
+        <!-- BUILD 11:27 F155 Esc RF button labels -->
+        <text name="wc_rf_pda_open_manager" text="Abrir gestor de trabajadores" />
+        <text name="sf_pda_btn_rotation_planner" text="Planificador de rotación" />
+        <text name="sf_pda_btn_field_detail" text="Detalle del campo" />
+    </texts>
+</l10n>

--- a/translations/translation_fc.xml
+++ b/translations/translation_fc.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<l10n>
+    <texts>
+        <!-- BUILD 11:27 F155 Esc RF button labels -->
+        <text name="wc_rf_pda_open_manager" text="Ouvrir le gestionnaire d'ouvriers" />
+        <text name="sf_pda_btn_rotation_planner" text="Planificateur de rotation" />
+        <text name="sf_pda_btn_field_detail" text="Détail du champ" />
+    </texts>
+</l10n>

--- a/translations/translation_fi.xml
+++ b/translations/translation_fi.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<l10n>
+    <texts>
+        <!-- BUILD 11:27 F155 Esc RF button labels -->
+        <text name="wc_rf_pda_open_manager" text="Avaa työntekijähallinta" />
+        <text name="sf_pda_btn_rotation_planner" text="Viljelykiertosuunnittelija" />
+        <text name="sf_pda_btn_field_detail" text="Pellon tiedot" />
+    </texts>
+</l10n>

--- a/translations/translation_fr.xml
+++ b/translations/translation_fr.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<l10n>
+    <texts>
+        <!-- BUILD 11:27 F155 Esc RF button labels -->
+        <text name="wc_rf_pda_open_manager" text="Ouvrir le gestionnaire d'ouvriers" />
+        <text name="sf_pda_btn_rotation_planner" text="Planificateur de rotation" />
+        <text name="sf_pda_btn_field_detail" text="Détail du champ" />
+    </texts>
+</l10n>

--- a/translations/translation_hu.xml
+++ b/translations/translation_hu.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<l10n>
+    <texts>
+        <!-- BUILD 11:27 F155 Esc RF button labels -->
+        <text name="wc_rf_pda_open_manager" text="Dolgozókezelő megnyitása" />
+        <text name="sf_pda_btn_rotation_planner" text="Vetésforgó-tervező" />
+        <text name="sf_pda_btn_field_detail" text="Táblarészletek" />
+    </texts>
+</l10n>

--- a/translations/translation_id.xml
+++ b/translations/translation_id.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<l10n>
+    <texts>
+        <!-- BUILD 11:27 F155 Esc RF button labels -->
+        <text name="wc_rf_pda_open_manager" text="Buka manajer pekerja" />
+        <text name="sf_pda_btn_rotation_planner" text="Perencana rotasi" />
+        <text name="sf_pda_btn_field_detail" text="Detail lahan" />
+    </texts>
+</l10n>

--- a/translations/translation_it.xml
+++ b/translations/translation_it.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<l10n>
+    <texts>
+        <!-- BUILD 11:27 F155 Esc RF button labels -->
+        <text name="wc_rf_pda_open_manager" text="Apri gestore operai" />
+        <text name="sf_pda_btn_rotation_planner" text="Pianificatore rotazioni" />
+        <text name="sf_pda_btn_field_detail" text="Dettaglio campo" />
+    </texts>
+</l10n>

--- a/translations/translation_jp.xml
+++ b/translations/translation_jp.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<l10n>
+    <texts>
+        <!-- BUILD 11:27 F155 Esc RF button labels -->
+        <text name="wc_rf_pda_open_manager" text="作業員マネージャーを開く" />
+        <text name="sf_pda_btn_rotation_planner" text="輪作プランナー" />
+        <text name="sf_pda_btn_field_detail" text="畑の詳細" />
+    </texts>
+</l10n>

--- a/translations/translation_kr.xml
+++ b/translations/translation_kr.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<l10n>
+    <texts>
+        <!-- BUILD 11:27 F155 Esc RF button labels -->
+        <text name="wc_rf_pda_open_manager" text="작업자 관리자 열기" />
+        <text name="sf_pda_btn_rotation_planner" text="윤작 계획기" />
+        <text name="sf_pda_btn_field_detail" text="밯 상세" />
+    </texts>
+</l10n>

--- a/translations/translation_nl.xml
+++ b/translations/translation_nl.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<l10n>
+    <texts>
+        <!-- BUILD 11:27 F155 Esc RF button labels -->
+        <text name="wc_rf_pda_open_manager" text="Werkersbeheer openen" />
+        <text name="sf_pda_btn_rotation_planner" text="Rotatieplanner" />
+        <text name="sf_pda_btn_field_detail" text="Veldgegevens" />
+    </texts>
+</l10n>

--- a/translations/translation_no.xml
+++ b/translations/translation_no.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<l10n>
+    <texts>
+        <!-- BUILD 11:27 F155 Esc RF button labels -->
+        <text name="wc_rf_pda_open_manager" text="Åpne arbeiderbehandler" />
+        <text name="sf_pda_btn_rotation_planner" text="Rotasjonsplanlegger" />
+        <text name="sf_pda_btn_field_detail" text="Feltdetaljer" />
+    </texts>
+</l10n>

--- a/translations/translation_pl.xml
+++ b/translations/translation_pl.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<l10n>
+    <texts>
+        <!-- BUILD 11:27 F155 Esc RF button labels -->
+        <text name="wc_rf_pda_open_manager" text="Otwórz menedżera pracowników" />
+        <text name="sf_pda_btn_rotation_planner" text="Planer płodozmianu" />
+        <text name="sf_pda_btn_field_detail" text="Szczegóły pola" />
+    </texts>
+</l10n>

--- a/translations/translation_pt.xml
+++ b/translations/translation_pt.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<l10n>
+    <texts>
+        <!-- BUILD 11:27 F155 Esc RF button labels -->
+        <text name="wc_rf_pda_open_manager" text="Abrir gestor de trabalhadores" />
+        <text name="sf_pda_btn_rotation_planner" text="Planeador de rotação" />
+        <text name="sf_pda_btn_field_detail" text="Detalhe do campo" />
+    </texts>
+</l10n>

--- a/translations/translation_ro.xml
+++ b/translations/translation_ro.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<l10n>
+    <texts>
+        <!-- BUILD 11:27 F155 Esc RF button labels -->
+        <text name="wc_rf_pda_open_manager" text="Deschide managerul de muncitori" />
+        <text name="sf_pda_btn_rotation_planner" text="Planificator de rotație" />
+        <text name="sf_pda_btn_field_detail" text="Detaliu câmp" />
+    </texts>
+</l10n>

--- a/translations/translation_ru.xml
+++ b/translations/translation_ru.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<l10n>
+    <texts>
+        <!-- BUILD 11:27 F155 Esc RF button labels -->
+        <text name="wc_rf_pda_open_manager" text="Открыть менеджер работников" />
+        <text name="sf_pda_btn_rotation_planner" text="Планировщик севооборота" />
+        <text name="sf_pda_btn_field_detail" text="Сведения о поле" />
+    </texts>
+</l10n>

--- a/translations/translation_sv.xml
+++ b/translations/translation_sv.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<l10n>
+    <texts>
+        <!-- BUILD 11:27 F155 Esc RF button labels -->
+        <text name="wc_rf_pda_open_manager" text="Öppna arbetshanteraren" />
+        <text name="sf_pda_btn_rotation_planner" text="Växtföljdsplanerare" />
+        <text name="sf_pda_btn_field_detail" text="Fältdetaljer" />
+    </texts>
+</l10n>

--- a/translations/translation_tr.xml
+++ b/translations/translation_tr.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<l10n>
+    <texts>
+        <!-- BUILD 11:27 F155 Esc RF button labels -->
+        <text name="wc_rf_pda_open_manager" text="İşçi yöneticisini aç" />
+        <text name="sf_pda_btn_rotation_planner" text="Ekim nöbeti planlayıcı" />
+        <text name="sf_pda_btn_field_detail" text="Tarla detayı" />
+    </texts>
+</l10n>

--- a/translations/translation_uk.xml
+++ b/translations/translation_uk.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<l10n>
+    <texts>
+        <!-- BUILD 11:27 F155 Esc RF button labels -->
+        <text name="wc_rf_pda_open_manager" text="Відкрити менеджер працівників" />
+        <text name="sf_pda_btn_rotation_planner" text="Планувальник сівозміни" />
+        <text name="sf_pda_btn_field_detail" text="Деталі поля" />
+    </texts>
+</l10n>

--- a/translations/translation_vi.xml
+++ b/translations/translation_vi.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<l10n>
+    <texts>
+        <!-- BUILD 11:27 F155 Esc RF button labels -->
+        <text name="wc_rf_pda_open_manager" text="Mở trình quản lý công nhân" />
+        <text name="sf_pda_btn_rotation_planner" text="Lập kế hoạch luân canh" />
+        <text name="sf_pda_btn_field_detail" text="Chi tiết thửa ruộng" />
+    </texts>
+</l10n>


### PR DESCRIPTION
## Summary
- Adds Esc RF PDA button labels for team language testing: Open Worker Manager, Rotation Planner, and Field Detail.
- Keys: `wc_rf_pda_open_manager`, `sf_pda_btn_rotation_planner`, `sf_pda_btn_field_detail`.
- Translation-only change onto `development` (no Esc chrome / farm patches).

## Test plan
- [ ] Set a non-English game language (e.g. German or French).
- [ ] Load the suite with Esc RF PDA available.
- [ ] Confirm the three Esc RF buttons show translated labels (not raw keys).
- [ ] Spot-check English still reads: Open Worker Manager / Rotation Planner / Field Detail.