### PR TITLE
Esc RF PDA: shared PRODUCTS–ROTATION freeze (clean)

### DIFF
--- a/modDesc.xml
+++ b/modDesc.xml
@@ -6,26 +6,26 @@
     <title>
         <en>Realistic Worker Costs</en>
         <de>Realistische Arbeiterkosten</de>
-        <fr>CoÃƒÆ’Ã‚Â»ts RÃƒÆ’Ã‚Â©alistes des Ouvriers</fr>
-        <pl>Realistyczne Koszty PracownikÃƒÆ’Ã‚Â³w</pl>
+        <fr>CoÃƒÂ»ts RÃƒÂ©alistes des Ouvriers</fr>
+        <pl>Realistyczne Koszty PracownikÃƒÂ³w</pl>
         <es>Costos Realistas de Trabajadores</es>
         <it>Costi Realistici Operai</it>
-        <cz>RealistickÃƒÆ’Ã‚Â© NÃƒÆ’Ã‚Â¡klady na PracovnÃƒÆ’Ã‚Â­ky</cz>
+        <cz>RealistickÃƒÂ© NÃƒÂ¡klady na PracovnÃƒÂ­ky</cz>
         <br>Custos Realistas de Trabalhadores</br>
-        <uk>ÃƒÂÃ‚Â ÃƒÂÃ‚ÂµÃƒÂÃ‚Â°ÃƒÂÃ‚Â»Ãƒâ€˜Ã¢â‚¬â€œÃƒâ€˜Ã‚ÂÃƒâ€˜Ã¢â‚¬Å¡ÃƒÂÃ‚Â¸Ãƒâ€˜Ã¢â‚¬Â¡ÃƒÂÃ‚Â½Ãƒâ€˜Ã¢â‚¬â€œ ÃƒÂÃ‚Â²ÃƒÂÃ‚Â¸Ãƒâ€˜Ã¢â‚¬Å¡Ãƒâ€˜Ã¢â€šÂ¬ÃƒÂÃ‚Â°Ãƒâ€˜Ã¢â‚¬Å¡ÃƒÂÃ‚Â¸ ÃƒÂÃ‚Â½ÃƒÂÃ‚Â° ÃƒÂÃ‚Â¿Ãƒâ€˜Ã¢â€šÂ¬ÃƒÂÃ‚Â°Ãƒâ€˜Ã¢â‚¬Â Ãƒâ€˜Ã¢â‚¬â€œÃƒÂÃ‚Â²ÃƒÂÃ‚Â½ÃƒÂÃ‚Â¸ÃƒÂÃ‚ÂºÃƒâ€˜Ã¢â‚¬â€œÃƒÂÃ‚Â²</uk>
-        <ru>ÃƒÂÃ‚Â ÃƒÂÃ‚ÂµÃƒÂÃ‚Â°ÃƒÂÃ‚Â»ÃƒÂÃ‚Â¸Ãƒâ€˜Ã‚ÂÃƒâ€˜Ã¢â‚¬Å¡ÃƒÂÃ‚Â¸Ãƒâ€˜Ã¢â‚¬Â¡ÃƒÂÃ‚Â½Ãƒâ€˜Ã¢â‚¬Â¹ÃƒÂÃ‚Âµ Ãƒâ€˜Ã¢â€šÂ¬ÃƒÂÃ‚Â°Ãƒâ€˜Ã‚ÂÃƒâ€˜Ã¢â‚¬Â¦ÃƒÂÃ‚Â¾ÃƒÂÃ‚Â´Ãƒâ€˜Ã¢â‚¬Â¹ ÃƒÂÃ‚Â½ÃƒÂÃ‚Â° Ãƒâ€˜Ã¢â€šÂ¬ÃƒÂÃ‚Â°ÃƒÂÃ‚Â±ÃƒÂÃ‚Â¾Ãƒâ€˜Ã¢â‚¬Å¡ÃƒÂÃ‚Â½ÃƒÂÃ‚Â¸ÃƒÂÃ‚ÂºÃƒÂÃ‚Â¾ÃƒÂÃ‚Â²</ru>
+        <uk>ÃÂ ÃÂµÃÂ°ÃÂ»Ã‘â€“Ã‘ÂÃ‘â€šÃÂ¸Ã‘â€¡ÃÂ½Ã‘â€“ ÃÂ²ÃÂ¸Ã‘â€šÃ‘â‚¬ÃÂ°Ã‘â€šÃÂ¸ ÃÂ½ÃÂ° ÃÂ¿Ã‘â‚¬ÃÂ°Ã‘â€ Ã‘â€“ÃÂ²ÃÂ½ÃÂ¸ÃÂºÃ‘â€“ÃÂ²</uk>
+        <ru>ÃÂ ÃÂµÃÂ°ÃÂ»ÃÂ¸Ã‘ÂÃ‘â€šÃÂ¸Ã‘â€¡ÃÂ½Ã‘â€¹ÃÂµ Ã‘â‚¬ÃÂ°Ã‘ÂÃ‘â€¦ÃÂ¾ÃÂ´Ã‘â€¹ ÃÂ½ÃÂ° Ã‘â‚¬ÃÂ°ÃÂ±ÃÂ¾Ã‘â€šÃÂ½ÃÂ¸ÃÂºÃÂ¾ÃÂ²</ru>
     </title>
     <description>
         <en>Adds hourly wages for workers with skill-based pricing and configurable rates.</en>
-        <de>FÃƒÆ’Ã‚Â¼gt stÃƒÆ’Ã‚Â¼ndliche LÃƒÆ’Ã‚Â¶hne fÃƒÆ’Ã‚Â¼r Arbeiter mit fÃƒÆ’Ã‚Â¤higkeitsbasierten Preisen und konfigurierbaren SÃƒÆ’Ã‚Â¤tzen hinzu.</de>
-        <fr>Ajoute des salaires horaires pour les ouvriers avec tarification basÃƒÆ’Ã‚Â©e sur les compÃƒÆ’Ã‚Â©tences et taux configurables.</fr>
-        <pl>Dodaje godzinowe stawki dla pracownikÃƒÆ’Ã‚Â³w z cenami opartymi na umiejÃƒâ€žÃ¢â€žÂ¢tnoÃƒâ€¦Ã¢â‚¬Âºciach i konfigurowalnymi stawkami.</pl>
-        <es>AÃƒÆ’Ã‚Â±ade salarios por hora para trabajadores con precios basados en habilidades y tarifas configurables.</es>
-        <it>Aggiunge salari orari per operai con prezzi basati su abilitÃƒÆ’Ã‚Â  e tariffe configurabili.</it>
-        <cz>PÃƒâ€¦Ã¢â€žÂ¢idÃƒÆ’Ã‚Â¡vÃƒÆ’Ã‚Â¡ hodinovÃƒÆ’Ã‚Â© mzdy pro pracovnÃƒÆ’Ã‚Â­ky s cenami zaloÃƒâ€¦Ã‚Â¾enÃƒÆ’Ã‚Â½mi na dovednostech a konfigurovatelnÃƒÆ’Ã‚Â½mi sazbami.</cz>
-        <br>Adiciona salÃƒÆ’Ã‚Â¡rios por hora para trabalhadores com preÃƒÆ’Ã‚Â§os baseados em habilidades e taxas configurÃƒÆ’Ã‚Â¡veis.</br>
-        <uk>ÃƒÂÃ¢â‚¬ÂÃƒÂÃ‚Â¾ÃƒÂÃ‚Â´ÃƒÂÃ‚Â°Ãƒâ€˜Ã¢â‚¬Â ÃƒÂÃ‚Â¿ÃƒÂÃ‚Â¾ÃƒÂÃ‚Â³ÃƒÂÃ‚Â¾ÃƒÂÃ‚Â´ÃƒÂÃ‚Â¸ÃƒÂÃ‚Â½ÃƒÂÃ‚Â½Ãƒâ€˜Ã†â€™ ÃƒÂÃ‚Â¾ÃƒÂÃ‚Â¿ÃƒÂÃ‚Â»ÃƒÂÃ‚Â°Ãƒâ€˜Ã¢â‚¬Å¡Ãƒâ€˜Ã†â€™ ÃƒÂÃ‚Â¿Ãƒâ€˜Ã¢â€šÂ¬ÃƒÂÃ‚Â°Ãƒâ€˜Ã¢â‚¬Â Ãƒâ€˜Ã¢â‚¬â€œÃƒÂÃ‚Â²ÃƒÂÃ‚Â½ÃƒÂÃ‚Â¸ÃƒÂÃ‚ÂºÃƒÂÃ‚Â°ÃƒÂÃ‚Â¼ ÃƒÂÃ‚Â· Ãƒâ€˜Ã¢â‚¬Â Ãƒâ€˜Ã¢â‚¬â€œÃƒÂÃ‚Â½ÃƒÂÃ‚Â¾Ãƒâ€˜Ã…Â½ ÃƒÂÃ‚Â½ÃƒÂÃ‚Â° ÃƒÂÃ‚Â¾Ãƒâ€˜Ã‚ÂÃƒÂÃ‚Â½ÃƒÂÃ‚Â¾ÃƒÂÃ‚Â²Ãƒâ€˜Ã¢â‚¬â€œ ÃƒÂÃ‚Â½ÃƒÂÃ‚Â°ÃƒÂÃ‚Â²ÃƒÂÃ‚Â¸Ãƒâ€˜Ã¢â‚¬Â¡ÃƒÂÃ‚Â¾ÃƒÂÃ‚Âº Ãƒâ€˜Ã¢â‚¬Å¡ÃƒÂÃ‚Â° ÃƒÂÃ‚Â½ÃƒÂÃ‚Â°Ãƒâ€˜Ã‚ÂÃƒâ€˜Ã¢â‚¬Å¡Ãƒâ€˜Ã¢â€šÂ¬ÃƒÂÃ‚Â¾Ãƒâ€˜Ã…Â½ÃƒÂÃ‚Â²ÃƒÂÃ‚Â°ÃƒÂÃ‚Â½ÃƒÂÃ‚Â¸ÃƒÂÃ‚Â¼ÃƒÂÃ‚Â¸ Ãƒâ€˜Ã‚ÂÃƒâ€˜Ã¢â‚¬Å¡ÃƒÂÃ‚Â°ÃƒÂÃ‚Â²ÃƒÂÃ‚ÂºÃƒÂÃ‚Â°ÃƒÂÃ‚Â¼ÃƒÂÃ‚Â¸.</uk>
-        <ru>ÃƒÂÃ¢â‚¬ÂÃƒÂÃ‚Â¾ÃƒÂÃ‚Â±ÃƒÂÃ‚Â°ÃƒÂÃ‚Â²ÃƒÂÃ‚Â»Ãƒâ€˜Ã‚ÂÃƒÂÃ‚ÂµÃƒâ€˜Ã¢â‚¬Å¡ ÃƒÂÃ‚Â¿ÃƒÂÃ‚Â¾Ãƒâ€˜Ã¢â‚¬Â¡ÃƒÂÃ‚Â°Ãƒâ€˜Ã‚ÂÃƒÂÃ‚Â¾ÃƒÂÃ‚Â²Ãƒâ€˜Ã†â€™Ãƒâ€˜Ã…Â½ ÃƒÂÃ‚Â¾ÃƒÂÃ‚Â¿ÃƒÂÃ‚Â»ÃƒÂÃ‚Â°Ãƒâ€˜Ã¢â‚¬Å¡Ãƒâ€˜Ã†â€™ Ãƒâ€˜Ã¢â€šÂ¬ÃƒÂÃ‚Â°ÃƒÂÃ‚Â±ÃƒÂÃ‚Â¾Ãƒâ€˜Ã¢â‚¬Å¡ÃƒÂÃ‚Â½ÃƒÂÃ‚Â¸ÃƒÂÃ‚ÂºÃƒÂÃ‚Â°ÃƒÂÃ‚Â¼ Ãƒâ€˜Ã‚Â Ãƒâ€˜Ã¢â‚¬Â ÃƒÂÃ‚ÂµÃƒÂÃ‚Â½ÃƒÂÃ‚Â°ÃƒÂÃ‚Â¼ÃƒÂÃ‚Â¸ ÃƒÂÃ‚Â½ÃƒÂÃ‚Â° ÃƒÂÃ‚Â¾Ãƒâ€˜Ã‚ÂÃƒÂÃ‚Â½ÃƒÂÃ‚Â¾ÃƒÂÃ‚Â²ÃƒÂÃ‚Âµ ÃƒÂÃ‚Â½ÃƒÂÃ‚Â°ÃƒÂÃ‚Â²Ãƒâ€˜Ã¢â‚¬Â¹ÃƒÂÃ‚ÂºÃƒÂÃ‚Â¾ÃƒÂÃ‚Â² ÃƒÂÃ‚Â¸ ÃƒÂÃ‚Â½ÃƒÂÃ‚Â°Ãƒâ€˜Ã‚ÂÃƒâ€˜Ã¢â‚¬Å¡Ãƒâ€˜Ã¢â€šÂ¬ÃƒÂÃ‚Â°ÃƒÂÃ‚Â¸ÃƒÂÃ‚Â²ÃƒÂÃ‚Â°ÃƒÂÃ‚ÂµÃƒÂÃ‚Â¼Ãƒâ€˜Ã¢â‚¬Â¹ÃƒÂÃ‚Â¼ÃƒÂÃ‚Â¸ Ãƒâ€˜Ã‚ÂÃƒâ€˜Ã¢â‚¬Å¡ÃƒÂÃ‚Â°ÃƒÂÃ‚Â²ÃƒÂÃ‚ÂºÃƒÂÃ‚Â°ÃƒÂÃ‚Â¼ÃƒÂÃ‚Â¸.</ru>
+        <de>FÃƒÂ¼gt stÃƒÂ¼ndliche LÃƒÂ¶hne fÃƒÂ¼r Arbeiter mit fÃƒÂ¤higkeitsbasierten Preisen und konfigurierbaren SÃƒÂ¤tzen hinzu.</de>
+        <fr>Ajoute des salaires horaires pour les ouvriers avec tarification basÃƒÂ©e sur les compÃƒÂ©tences et taux configurables.</fr>
+        <pl>Dodaje godzinowe stawki dla pracownikÃƒÂ³w z cenami opartymi na umiejÃ„â„¢tnoÃ…â€ºciach i konfigurowalnymi stawkami.</pl>
+        <es>AÃƒÂ±ade salarios por hora para trabajadores con precios basados en habilidades y tarifas configurables.</es>
+        <it>Aggiunge salari orari per operai con prezzi basati su abilitÃƒÂ  e tariffe configurabili.</it>
+        <cz>PÃ…â„¢idÃƒÂ¡vÃƒÂ¡ hodinovÃƒÂ© mzdy pro pracovnÃƒÂ­ky s cenami zaloÃ…Â¾enÃƒÂ½mi na dovednostech a konfigurovatelnÃƒÂ½mi sazbami.</cz>
+        <br>Adiciona salÃƒÂ¡rios por hora para trabalhadores com preÃƒÂ§os baseados em habilidades e taxas configurÃƒÂ¡veis.</br>
+        <uk>Ãâ€ÃÂ¾ÃÂ´ÃÂ°Ã‘â€ ÃÂ¿ÃÂ¾ÃÂ³ÃÂ¾ÃÂ´ÃÂ¸ÃÂ½ÃÂ½Ã‘Æ’ ÃÂ¾ÃÂ¿ÃÂ»ÃÂ°Ã‘â€šÃ‘Æ’ ÃÂ¿Ã‘â‚¬ÃÂ°Ã‘â€ Ã‘â€“ÃÂ²ÃÂ½ÃÂ¸ÃÂºÃÂ°ÃÂ¼ ÃÂ· Ã‘â€ Ã‘â€“ÃÂ½ÃÂ¾Ã‘Å½ ÃÂ½ÃÂ° ÃÂ¾Ã‘ÂÃÂ½ÃÂ¾ÃÂ²Ã‘â€“ ÃÂ½ÃÂ°ÃÂ²ÃÂ¸Ã‘â€¡ÃÂ¾ÃÂº Ã‘â€šÃÂ° ÃÂ½ÃÂ°Ã‘ÂÃ‘â€šÃ‘â‚¬ÃÂ¾Ã‘Å½ÃÂ²ÃÂ°ÃÂ½ÃÂ¸ÃÂ¼ÃÂ¸ Ã‘ÂÃ‘â€šÃÂ°ÃÂ²ÃÂºÃÂ°ÃÂ¼ÃÂ¸.</uk>
+        <ru>Ãâ€ÃÂ¾ÃÂ±ÃÂ°ÃÂ²ÃÂ»Ã‘ÂÃÂµÃ‘â€š ÃÂ¿ÃÂ¾Ã‘â€¡ÃÂ°Ã‘ÂÃÂ¾ÃÂ²Ã‘Æ’Ã‘Å½ ÃÂ¾ÃÂ¿ÃÂ»ÃÂ°Ã‘â€šÃ‘Æ’ Ã‘â‚¬ÃÂ°ÃÂ±ÃÂ¾Ã‘â€šÃÂ½ÃÂ¸ÃÂºÃÂ°ÃÂ¼ Ã‘Â Ã‘â€ ÃÂµÃÂ½ÃÂ°ÃÂ¼ÃÂ¸ ÃÂ½ÃÂ° ÃÂ¾Ã‘ÂÃÂ½ÃÂ¾ÃÂ²ÃÂµ ÃÂ½ÃÂ°ÃÂ²Ã‘â€¹ÃÂºÃÂ¾ÃÂ² ÃÂ¸ ÃÂ½ÃÂ°Ã‘ÂÃ‘â€šÃ‘â‚¬ÃÂ°ÃÂ¸ÃÂ²ÃÂ°ÃÂµÃÂ¼Ã‘â€¹ÃÂ¼ÃÂ¸ Ã‘ÂÃ‘â€šÃÂ°ÃÂ²ÃÂºÃÂ°ÃÂ¼ÃÂ¸.</ru>
     </description>
     <iconFilename>icon.dds</iconFilename>
     
@@ -43,43 +43,43 @@
         <text name="wc_section">
             <en>Worker Costs Mod</en>
             <de>Arbeiterkosten-Mod</de>
-            <fr>Module CoÃƒÆ’Ã‚Â»ts Ouvriers</fr>
-            <pl>Mod KosztÃƒÆ’Ã‚Â³w PracownikÃƒÆ’Ã‚Â³w</pl>
+            <fr>Module CoÃƒÂ»ts Ouvriers</fr>
+            <pl>Mod KosztÃƒÂ³w PracownikÃƒÂ³w</pl>
             <es>Mod Costos Trabajadores</es>
             <it>Mod Costi Operai</it>
-            <cz>Mod NÃƒÆ’Ã‚Â¡kladÃƒâ€¦Ã‚Â¯ na PracovnÃƒÆ’Ã‚Â­ky</cz>
+            <cz>Mod NÃƒÂ¡kladÃ…Â¯ na PracovnÃƒÂ­ky</cz>
             <br>Mod Custos Trabalhadores</br>
-            <uk>ÃƒÂÃ…â€œÃƒÂÃ‚Â¾ÃƒÂÃ‚Â´ ÃƒÂÃ‚Â²ÃƒÂÃ‚Â¸Ãƒâ€˜Ã¢â‚¬Å¡Ãƒâ€˜Ã¢â€šÂ¬ÃƒÂÃ‚Â°Ãƒâ€˜Ã¢â‚¬Å¡ ÃƒÂÃ‚Â½ÃƒÂÃ‚Â° ÃƒÂÃ‚Â¿Ãƒâ€˜Ã¢â€šÂ¬ÃƒÂÃ‚Â°Ãƒâ€˜Ã¢â‚¬Â Ãƒâ€˜Ã¢â‚¬â€œÃƒÂÃ‚Â²ÃƒÂÃ‚Â½ÃƒÂÃ‚Â¸ÃƒÂÃ‚ÂºÃƒâ€˜Ã¢â‚¬â€œÃƒÂÃ‚Â²</uk>
-            <ru>ÃƒÂÃ…â€œÃƒÂÃ‚Â¾ÃƒÂÃ‚Â´ Ãƒâ€˜Ã¢â€šÂ¬ÃƒÂÃ‚Â°Ãƒâ€˜Ã‚ÂÃƒâ€˜Ã¢â‚¬Â¦ÃƒÂÃ‚Â¾ÃƒÂÃ‚Â´ÃƒÂÃ‚Â¾ÃƒÂÃ‚Â² ÃƒÂÃ‚Â½ÃƒÂÃ‚Â° Ãƒâ€˜Ã¢â€šÂ¬ÃƒÂÃ‚Â°ÃƒÂÃ‚Â±ÃƒÂÃ‚Â¾Ãƒâ€˜Ã¢â‚¬Å¡ÃƒÂÃ‚Â½ÃƒÂÃ‚Â¸ÃƒÂÃ‚ÂºÃƒÂÃ‚Â¾ÃƒÂÃ‚Â²</ru>
+            <uk>ÃÅ“ÃÂ¾ÃÂ´ ÃÂ²ÃÂ¸Ã‘â€šÃ‘â‚¬ÃÂ°Ã‘â€š ÃÂ½ÃÂ° ÃÂ¿Ã‘â‚¬ÃÂ°Ã‘â€ Ã‘â€“ÃÂ²ÃÂ½ÃÂ¸ÃÂºÃ‘â€“ÃÂ²</uk>
+            <ru>ÃÅ“ÃÂ¾ÃÂ´ Ã‘â‚¬ÃÂ°Ã‘ÂÃ‘â€¦ÃÂ¾ÃÂ´ÃÂ¾ÃÂ² ÃÂ½ÃÂ° Ã‘â‚¬ÃÂ°ÃÂ±ÃÂ¾Ã‘â€šÃÂ½ÃÂ¸ÃÂºÃÂ¾ÃÂ²</ru>
         
             <da>Mod til medarbejderomkostninger</da>
         </text>
 
         <text name="input_WC_OPEN_ROSTER">
             <en>Open Worker Roster</en>
-            <de>Arbeiterliste ÃƒÆ’Ã‚Â¶ffnen</de>
+            <de>Arbeiterliste ÃƒÂ¶ffnen</de>
             <fr>Ouvrir la liste des ouvriers</fr>
-            <pl>OtwÃƒÆ’Ã‚Â³rz listÃƒâ€žÃ¢â€žÂ¢ pracownikÃƒÆ’Ã‚Â³w</pl>
+            <pl>OtwÃƒÂ³rz listÃ„â„¢ pracownikÃƒÂ³w</pl>
             <es>Abrir lista de trabajadores</es>
             <it>Apri elenco operai</it>
-            <cz>OtevÃƒâ€¦Ã¢â€žÂ¢ÃƒÆ’Ã‚Â­t seznam pracovnÃƒÆ’Ã‚Â­kÃƒâ€¦Ã‚Â¯</cz>
+            <cz>OtevÃ…â„¢ÃƒÂ­t seznam pracovnÃƒÂ­kÃ…Â¯</cz>
             <br>Abrir lista de trabalhadores</br>
-            <uk>ÃƒÂÃ¢â‚¬â„¢Ãƒâ€˜Ã¢â‚¬â€œÃƒÂÃ‚Â´ÃƒÂÃ‚ÂºÃƒâ€˜Ã¢â€šÂ¬ÃƒÂÃ‚Â¸Ãƒâ€˜Ã¢â‚¬Å¡ÃƒÂÃ‚Â¸ Ãƒâ€˜Ã‚ÂÃƒÂÃ‚Â¿ÃƒÂÃ‚Â¸Ãƒâ€˜Ã‚ÂÃƒÂÃ‚Â¾ÃƒÂÃ‚Âº ÃƒÂÃ‚Â¿Ãƒâ€˜Ã¢â€šÂ¬ÃƒÂÃ‚Â°Ãƒâ€˜Ã¢â‚¬Â Ãƒâ€˜Ã¢â‚¬â€œÃƒÂÃ‚Â²ÃƒÂÃ‚Â½ÃƒÂÃ‚Â¸ÃƒÂÃ‚ÂºÃƒâ€˜Ã¢â‚¬â€œÃƒÂÃ‚Â²</uk>
-            <ru>ÃƒÂÃ…Â¾Ãƒâ€˜Ã¢â‚¬Å¡ÃƒÂÃ‚ÂºÃƒâ€˜Ã¢â€šÂ¬Ãƒâ€˜Ã¢â‚¬Â¹Ãƒâ€˜Ã¢â‚¬Å¡Ãƒâ€˜Ã…â€™ Ãƒâ€˜Ã‚ÂÃƒÂÃ‚Â¿ÃƒÂÃ‚Â¸Ãƒâ€˜Ã‚ÂÃƒÂÃ‚Â¾ÃƒÂÃ‚Âº Ãƒâ€˜Ã¢â€šÂ¬ÃƒÂÃ‚Â°ÃƒÂÃ‚Â±ÃƒÂÃ‚Â¾Ãƒâ€˜Ã¢â‚¬Å¡ÃƒÂÃ‚Â½ÃƒÂÃ‚Â¸ÃƒÂÃ‚ÂºÃƒÂÃ‚Â¾ÃƒÂÃ‚Â²</ru>
-            <da>ÃƒÆ’Ã¢â‚¬Â¦bn medarbejderliste</da>
+            <uk>Ãâ€™Ã‘â€“ÃÂ´ÃÂºÃ‘â‚¬ÃÂ¸Ã‘â€šÃÂ¸ Ã‘ÂÃÂ¿ÃÂ¸Ã‘ÂÃÂ¾ÃÂº ÃÂ¿Ã‘â‚¬ÃÂ°Ã‘â€ Ã‘â€“ÃÂ²ÃÂ½ÃÂ¸ÃÂºÃ‘â€“ÃÂ²</uk>
+            <ru>ÃÅ¾Ã‘â€šÃÂºÃ‘â‚¬Ã‘â€¹Ã‘â€šÃ‘Å’ Ã‘ÂÃÂ¿ÃÂ¸Ã‘ÂÃÂ¾ÃÂº Ã‘â‚¬ÃÂ°ÃÂ±ÃÂ¾Ã‘â€šÃÂ½ÃÂ¸ÃÂºÃÂ¾ÃÂ²</ru>
+            <da>Ãƒâ€¦bn medarbejderliste</da>
         </text>
 
         <text name="wc_enabled_short">
             <en>Enable Mod</en>
             <de>Mod aktivieren</de>
             <fr>Activer le mod</fr>
-            <pl>WÃƒâ€¦Ã¢â‚¬Å¡Ãƒâ€žÃ¢â‚¬Â¦cz mod</pl>
+            <pl>WÃ…â€šÃ„â€¦cz mod</pl>
             <es>Activar mod</es>
             <it>Attiva mod</it>
             <cz>Povolit mod</cz>
             <br>Ativar mod</br>
-            <uk>ÃƒÂÃ‚Â£ÃƒÂÃ‚Â²Ãƒâ€˜Ã¢â‚¬â€œÃƒÂÃ‚Â¼ÃƒÂÃ‚ÂºÃƒÂÃ‚Â½Ãƒâ€˜Ã†â€™Ãƒâ€˜Ã¢â‚¬Å¡ÃƒÂÃ‚Â¸ ÃƒÂÃ‚Â¼ÃƒÂÃ‚Â¾ÃƒÂÃ‚Â´</uk>
-            <ru>ÃƒÂÃ¢â‚¬â„¢ÃƒÂÃ‚ÂºÃƒÂÃ‚Â»Ãƒâ€˜Ã…Â½Ãƒâ€˜Ã¢â‚¬Â¡ÃƒÂÃ‚Â¸Ãƒâ€˜Ã¢â‚¬Å¡Ãƒâ€˜Ã…â€™ ÃƒÂÃ‚Â¼ÃƒÂÃ‚Â¾ÃƒÂÃ‚Â´</ru>
+            <uk>ÃÂ£ÃÂ²Ã‘â€“ÃÂ¼ÃÂºÃÂ½Ã‘Æ’Ã‘â€šÃÂ¸ ÃÂ¼ÃÂ¾ÃÂ´</uk>
+            <ru>Ãâ€™ÃÂºÃÂ»Ã‘Å½Ã‘â€¡ÃÂ¸Ã‘â€šÃ‘Å’ ÃÂ¼ÃÂ¾ÃÂ´</ru>
         
             <da>Aktiver Mod</da>
         </text>
@@ -87,16 +87,16 @@
         <text name="wc_enabled_long">
             <en>Enable or disable the worker costs mod</en>
             <de>Arbeiterkosten-Mod aktivieren oder deaktivieren</de>
-            <fr>Activer ou dÃƒÆ’Ã‚Â©sactiver le module de coÃƒÆ’Ã‚Â»ts des ouvriers</fr>
-            <pl>WÃƒâ€¦Ã¢â‚¬Å¡Ãƒâ€žÃ¢â‚¬Â¦cz lub wyÃƒâ€¦Ã¢â‚¬Å¡Ãƒâ€žÃ¢â‚¬Â¦cz mod kosztÃƒÆ’Ã‚Â³w pracownikÃƒÆ’Ã‚Â³w</pl>
-            <es>Activar o desactivar el mÃƒÆ’Ã‚Â³dulo de costos de trabajadores</es>
+            <fr>Activer ou dÃƒÂ©sactiver le module de coÃƒÂ»ts des ouvriers</fr>
+            <pl>WÃ…â€šÃ„â€¦cz lub wyÃ…â€šÃ„â€¦cz mod kosztÃƒÂ³w pracownikÃƒÂ³w</pl>
+            <es>Activar o desactivar el mÃƒÂ³dulo de costos de trabajadores</es>
             <it>Attiva o disattiva il modulo dei costi degli operai</it>
-            <cz>Povolit nebo zakÃƒÆ’Ã‚Â¡zat mod nÃƒÆ’Ã‚Â¡kladÃƒâ€¦Ã‚Â¯ na pracovnÃƒÆ’Ã‚Â­ky</cz>
+            <cz>Povolit nebo zakÃƒÂ¡zat mod nÃƒÂ¡kladÃ…Â¯ na pracovnÃƒÂ­ky</cz>
             <br>Ativar ou desativar o mod de custos de trabalhadores</br>
-            <uk>ÃƒÂÃ‚Â£ÃƒÂÃ‚Â²Ãƒâ€˜Ã¢â‚¬â€œÃƒÂÃ‚Â¼ÃƒÂÃ‚ÂºÃƒÂÃ‚Â½Ãƒâ€˜Ã†â€™Ãƒâ€˜Ã¢â‚¬Å¡ÃƒÂÃ‚Â¸ ÃƒÂÃ‚Â°ÃƒÂÃ‚Â±ÃƒÂÃ‚Â¾ ÃƒÂÃ‚Â²ÃƒÂÃ‚Â¸ÃƒÂÃ‚Â¼ÃƒÂÃ‚ÂºÃƒÂÃ‚Â½Ãƒâ€˜Ã†â€™Ãƒâ€˜Ã¢â‚¬Å¡ÃƒÂÃ‚Â¸ ÃƒÂÃ‚Â¼ÃƒÂÃ‚Â¾ÃƒÂÃ‚Â´ ÃƒÂÃ‚Â²ÃƒÂÃ‚Â¸Ãƒâ€˜Ã¢â‚¬Å¡Ãƒâ€˜Ã¢â€šÂ¬ÃƒÂÃ‚Â°Ãƒâ€˜Ã¢â‚¬Å¡ ÃƒÂÃ‚Â½ÃƒÂÃ‚Â° ÃƒÂÃ‚Â¿Ãƒâ€˜Ã¢â€šÂ¬ÃƒÂÃ‚Â°Ãƒâ€˜Ã¢â‚¬Â Ãƒâ€˜Ã¢â‚¬â€œÃƒÂÃ‚Â²ÃƒÂÃ‚Â½ÃƒÂÃ‚Â¸ÃƒÂÃ‚ÂºÃƒâ€˜Ã¢â‚¬â€œÃƒÂÃ‚Â²</uk>
-            <ru>ÃƒÂÃ¢â‚¬â„¢ÃƒÂÃ‚ÂºÃƒÂÃ‚Â»Ãƒâ€˜Ã…Â½Ãƒâ€˜Ã¢â‚¬Â¡ÃƒÂÃ‚Â¸Ãƒâ€˜Ã¢â‚¬Å¡Ãƒâ€˜Ã…â€™ ÃƒÂÃ‚Â¸ÃƒÂÃ‚Â»ÃƒÂÃ‚Â¸ ÃƒÂÃ‚Â²Ãƒâ€˜Ã¢â‚¬Â¹ÃƒÂÃ‚ÂºÃƒÂÃ‚Â»Ãƒâ€˜Ã…Â½Ãƒâ€˜Ã¢â‚¬Â¡ÃƒÂÃ‚Â¸Ãƒâ€˜Ã¢â‚¬Å¡Ãƒâ€˜Ã…â€™ ÃƒÂÃ‚Â¼ÃƒÂÃ‚Â¾ÃƒÂÃ‚Â´ Ãƒâ€˜Ã¢â€šÂ¬ÃƒÂÃ‚Â°Ãƒâ€˜Ã‚ÂÃƒâ€˜Ã¢â‚¬Â¦ÃƒÂÃ‚Â¾ÃƒÂÃ‚Â´ÃƒÂÃ‚Â¾ÃƒÂÃ‚Â² ÃƒÂÃ‚Â½ÃƒÂÃ‚Â° Ãƒâ€˜Ã¢â€šÂ¬ÃƒÂÃ‚Â°ÃƒÂÃ‚Â±ÃƒÂÃ‚Â¾Ãƒâ€˜Ã¢â‚¬Å¡ÃƒÂÃ‚Â½ÃƒÂÃ‚Â¸ÃƒÂÃ‚ÂºÃƒÂÃ‚Â¾ÃƒÂÃ‚Â²</ru>
+            <uk>ÃÂ£ÃÂ²Ã‘â€“ÃÂ¼ÃÂºÃÂ½Ã‘Æ’Ã‘â€šÃÂ¸ ÃÂ°ÃÂ±ÃÂ¾ ÃÂ²ÃÂ¸ÃÂ¼ÃÂºÃÂ½Ã‘Æ’Ã‘â€šÃÂ¸ ÃÂ¼ÃÂ¾ÃÂ´ ÃÂ²ÃÂ¸Ã‘â€šÃ‘â‚¬ÃÂ°Ã‘â€š ÃÂ½ÃÂ° ÃÂ¿Ã‘â‚¬ÃÂ°Ã‘â€ Ã‘â€“ÃÂ²ÃÂ½ÃÂ¸ÃÂºÃ‘â€“ÃÂ²</uk>
+            <ru>Ãâ€™ÃÂºÃÂ»Ã‘Å½Ã‘â€¡ÃÂ¸Ã‘â€šÃ‘Å’ ÃÂ¸ÃÂ»ÃÂ¸ ÃÂ²Ã‘â€¹ÃÂºÃÂ»Ã‘Å½Ã‘â€¡ÃÂ¸Ã‘â€šÃ‘Å’ ÃÂ¼ÃÂ¾ÃÂ´ Ã‘â‚¬ÃÂ°Ã‘ÂÃ‘â€¦ÃÂ¾ÃÂ´ÃÂ¾ÃÂ² ÃÂ½ÃÂ° Ã‘â‚¬ÃÂ°ÃÂ±ÃÂ¾Ã‘â€šÃÂ½ÃÂ¸ÃÂºÃÂ¾ÃÂ²</ru>
         
-            <da>AktivÃƒÆ’Ã‚Â©r eller deaktiver modÃƒÂ¢Ã¢â€šÂ¬Ã¢â€žÂ¢en for medarbejderomkostninger</da>
+            <da>AktivÃƒÂ©r eller deaktiver modÃ¢â‚¬â„¢en for medarbejderomkostninger</da>
         </text>
         
         <text name="wc_debug_short">
@@ -105,57 +105,57 @@
             <fr>Mode DEBUG</fr>
             <pl>Tryb DEBUG</pl>
             <es>Modo DEBUG</es>
-            <it>ModalitÃƒÆ’Ã‚Â  DEBUG</it>
-            <cz>DEBUG reÃƒâ€¦Ã‚Â¾im</cz>
+            <it>ModalitÃƒÂ  DEBUG</it>
+            <cz>DEBUG reÃ…Â¾im</cz>
             <br>Modo DEBUG</br>
-            <uk>ÃƒÂÃ‚Â ÃƒÂÃ‚ÂµÃƒÂÃ‚Â¶ÃƒÂÃ‚Â¸ÃƒÂÃ‚Â¼ DEBUG</uk>
-            <ru>ÃƒÂÃ‚Â ÃƒÂÃ‚ÂµÃƒÂÃ‚Â¶ÃƒÂÃ‚Â¸ÃƒÂÃ‚Â¼ DEBUG</ru>
+            <uk>ÃÂ ÃÂµÃÂ¶ÃÂ¸ÃÂ¼ DEBUG</uk>
+            <ru>ÃÂ ÃÂµÃÂ¶ÃÂ¸ÃÂ¼ DEBUG</ru>
         
             <da>Debug-tilstand</da>
         </text>
         
         <text name="wc_debug_long">
             <en>Enable/disable debug mode (extra logging)</en>
-            <de>DEBUG-Modus ein-/ausschalten (zusÃƒÆ’Ã‚Â¤tzliche Protokollierung)</de>
-            <fr>Activer/dÃƒÆ’Ã‚Â©sactiver le mode DEBUG (journalisation supplÃƒÆ’Ã‚Â©mentaire)</fr>
-            <pl>WÃƒâ€¦Ã¢â‚¬Å¡Ãƒâ€žÃ¢â‚¬Â¦cz/wyÃƒâ€¦Ã¢â‚¬Å¡Ãƒâ€žÃ¢â‚¬Â¦cz tryb DEBUG (dodatkowe logowanie)</pl>
+            <de>DEBUG-Modus ein-/ausschalten (zusÃƒÂ¤tzliche Protokollierung)</de>
+            <fr>Activer/dÃƒÂ©sactiver le mode DEBUG (journalisation supplÃƒÂ©mentaire)</fr>
+            <pl>WÃ…â€šÃ„â€¦cz/wyÃ…â€šÃ„â€¦cz tryb DEBUG (dodatkowe logowanie)</pl>
             <es>Activar/desactivar modo DEBUG (registro adicional)</es>
-            <it>Attiva/disattiva modalitÃƒÆ’Ã‚Â  DEBUG (registrazione aggiuntiva)</it>
-            <cz>Povolit/zakÃƒÆ’Ã‚Â¡zat DEBUG reÃƒâ€¦Ã‚Â¾im (dodateÃƒâ€žÃ‚ÂnÃƒÆ’Ã‚Â© logovÃƒÆ’Ã‚Â¡nÃƒÆ’Ã‚Â­)</cz>
+            <it>Attiva/disattiva modalitÃƒÂ  DEBUG (registrazione aggiuntiva)</it>
+            <cz>Povolit/zakÃƒÂ¡zat DEBUG reÃ…Â¾im (dodateÃ„ÂnÃƒÂ© logovÃƒÂ¡nÃƒÂ­)</cz>
             <br>Ativar/desativar modo DEBUG (registro adicional)</br>
-            <uk>ÃƒÂÃ‚Â£ÃƒÂÃ‚Â²Ãƒâ€˜Ã¢â‚¬â€œÃƒÂÃ‚Â¼ÃƒÂÃ‚ÂºÃƒÂÃ‚Â½Ãƒâ€˜Ã†â€™Ãƒâ€˜Ã¢â‚¬Å¡ÃƒÂÃ‚Â¸/ÃƒÂÃ‚Â²ÃƒÂÃ‚Â¸ÃƒÂÃ‚Â¼ÃƒÂÃ‚ÂºÃƒÂÃ‚Â½Ãƒâ€˜Ã†â€™Ãƒâ€˜Ã¢â‚¬Å¡ÃƒÂÃ‚Â¸ Ãƒâ€˜Ã¢â€šÂ¬ÃƒÂÃ‚ÂµÃƒÂÃ‚Â¶ÃƒÂÃ‚Â¸ÃƒÂÃ‚Â¼ DEBUG (ÃƒÂÃ‚Â´ÃƒÂÃ‚Â¾ÃƒÂÃ‚Â´ÃƒÂÃ‚Â°Ãƒâ€˜Ã¢â‚¬Å¡ÃƒÂÃ‚ÂºÃƒÂÃ‚Â¾ÃƒÂÃ‚Â²ÃƒÂÃ‚Âµ ÃƒÂÃ‚Â»ÃƒÂÃ‚Â¾ÃƒÂÃ‚Â³Ãƒâ€˜Ã†â€™ÃƒÂÃ‚Â²ÃƒÂÃ‚Â°ÃƒÂÃ‚Â½ÃƒÂÃ‚Â½Ãƒâ€˜Ã‚Â)</uk>
-            <ru>ÃƒÂÃ¢â‚¬â„¢ÃƒÂÃ‚ÂºÃƒÂÃ‚Â»Ãƒâ€˜Ã…Â½Ãƒâ€˜Ã¢â‚¬Â¡ÃƒÂÃ‚Â¸Ãƒâ€˜Ã¢â‚¬Å¡Ãƒâ€˜Ã…â€™/ÃƒÂÃ‚Â²Ãƒâ€˜Ã¢â‚¬Â¹ÃƒÂÃ‚ÂºÃƒÂÃ‚Â»Ãƒâ€˜Ã…Â½Ãƒâ€˜Ã¢â‚¬Â¡ÃƒÂÃ‚Â¸Ãƒâ€˜Ã¢â‚¬Å¡Ãƒâ€˜Ã…â€™ Ãƒâ€˜Ã¢â€šÂ¬ÃƒÂÃ‚ÂµÃƒÂÃ‚Â¶ÃƒÂÃ‚Â¸ÃƒÂÃ‚Â¼ DEBUG (ÃƒÂÃ‚Â´ÃƒÂÃ‚Â¾ÃƒÂÃ‚Â¿ÃƒÂÃ‚Â¾ÃƒÂÃ‚Â»ÃƒÂÃ‚Â½ÃƒÂÃ‚Â¸Ãƒâ€˜Ã¢â‚¬Å¡ÃƒÂÃ‚ÂµÃƒÂÃ‚Â»Ãƒâ€˜Ã…â€™ÃƒÂÃ‚Â½ÃƒÂÃ‚Â¾ÃƒÂÃ‚Âµ ÃƒÂÃ‚Â»ÃƒÂÃ‚Â¾ÃƒÂÃ‚Â³ÃƒÂÃ‚Â¸Ãƒâ€˜Ã¢â€šÂ¬ÃƒÂÃ‚Â¾ÃƒÂÃ‚Â²ÃƒÂÃ‚Â°ÃƒÂÃ‚Â½ÃƒÂÃ‚Â¸ÃƒÂÃ‚Âµ)</ru>
+            <uk>ÃÂ£ÃÂ²Ã‘â€“ÃÂ¼ÃÂºÃÂ½Ã‘Æ’Ã‘â€šÃÂ¸/ÃÂ²ÃÂ¸ÃÂ¼ÃÂºÃÂ½Ã‘Æ’Ã‘â€šÃÂ¸ Ã‘â‚¬ÃÂµÃÂ¶ÃÂ¸ÃÂ¼ DEBUG (ÃÂ´ÃÂ¾ÃÂ´ÃÂ°Ã‘â€šÃÂºÃÂ¾ÃÂ²ÃÂµ ÃÂ»ÃÂ¾ÃÂ³Ã‘Æ’ÃÂ²ÃÂ°ÃÂ½ÃÂ½Ã‘Â)</uk>
+            <ru>Ãâ€™ÃÂºÃÂ»Ã‘Å½Ã‘â€¡ÃÂ¸Ã‘â€šÃ‘Å’/ÃÂ²Ã‘â€¹ÃÂºÃÂ»Ã‘Å½Ã‘â€¡ÃÂ¸Ã‘â€šÃ‘Å’ Ã‘â‚¬ÃÂµÃÂ¶ÃÂ¸ÃÂ¼ DEBUG (ÃÂ´ÃÂ¾ÃÂ¿ÃÂ¾ÃÂ»ÃÂ½ÃÂ¸Ã‘â€šÃÂµÃÂ»Ã‘Å’ÃÂ½ÃÂ¾ÃÂµ ÃÂ»ÃÂ¾ÃÂ³ÃÂ¸Ã‘â‚¬ÃÂ¾ÃÂ²ÃÂ°ÃÂ½ÃÂ¸ÃÂµ)</ru>
         
-            <da>SlÃƒÆ’Ã‚Â¥ debug-tilstand til/fra (ekstra logning)</da>
+            <da>SlÃƒÂ¥ debug-tilstand til/fra (ekstra logning)</da>
         </text>
         
         
         <text name="wc_costmode_long">
             <en>Choose cost calculation: hourly or per hectare</en>
-            <de>WÃƒÆ’Ã‚Â¤hlen Sie die Kostenberechnung: stÃƒÆ’Ã‚Â¼ndlich oder pro Hektar</de>
-            <fr>Choisissez le calcul des coÃƒÆ’Ã‚Â»ts : horaire ou par hectare</fr>
-            <pl>Wybierz obliczanie kosztÃƒÆ’Ã‚Â³w: godzinowe lub za hektar</pl>
-            <es>Elegir cÃƒÆ’Ã‚Â¡lculo de costos: por hora o por hectÃƒÆ’Ã‚Â¡rea</es>
+            <de>WÃƒÂ¤hlen Sie die Kostenberechnung: stÃƒÂ¼ndlich oder pro Hektar</de>
+            <fr>Choisissez le calcul des coÃƒÂ»ts : horaire ou par hectare</fr>
+            <pl>Wybierz obliczanie kosztÃƒÂ³w: godzinowe lub za hektar</pl>
+            <es>Elegir cÃƒÂ¡lculo de costos: por hora o por hectÃƒÂ¡rea</es>
             <it>Scegli calcolo costi: orario o per ettaro</it>
-            <cz>Vyberte vÃƒÆ’Ã‚Â½poÃƒâ€žÃ‚Âet nÃƒÆ’Ã‚Â¡kladÃƒâ€¦Ã‚Â¯: hodinovÃƒÆ’Ã‚Â½ nebo na hektar</cz>
-            <br>Escolher cÃƒÆ’Ã‚Â¡lculo de custos: por hora ou por hectare</br>
-            <uk>ÃƒÂÃ¢â‚¬â„¢ÃƒÂÃ‚Â¸ÃƒÂÃ‚Â±ÃƒÂÃ‚ÂµÃƒâ€˜Ã¢â€šÂ¬Ãƒâ€˜Ã¢â‚¬â€œÃƒâ€˜Ã¢â‚¬Å¡Ãƒâ€˜Ã…â€™ Ãƒâ€˜Ã¢â€šÂ¬ÃƒÂÃ‚Â¾ÃƒÂÃ‚Â·Ãƒâ€˜Ã¢â€šÂ¬ÃƒÂÃ‚Â°Ãƒâ€˜Ã¢â‚¬Â¦Ãƒâ€˜Ã†â€™ÃƒÂÃ‚Â½ÃƒÂÃ‚Â¾ÃƒÂÃ‚Âº ÃƒÂÃ‚Â²ÃƒÂÃ‚Â¸Ãƒâ€˜Ã¢â‚¬Å¡Ãƒâ€˜Ã¢â€šÂ¬ÃƒÂÃ‚Â°Ãƒâ€˜Ã¢â‚¬Å¡: ÃƒÂÃ‚Â¿ÃƒÂÃ‚Â¾ÃƒÂÃ‚Â³ÃƒÂÃ‚Â¾ÃƒÂÃ‚Â´ÃƒÂÃ‚Â¸ÃƒÂÃ‚Â½ÃƒÂÃ‚Â½ÃƒÂÃ‚Â¾ ÃƒÂÃ‚Â°ÃƒÂÃ‚Â±ÃƒÂÃ‚Â¾ ÃƒÂÃ‚Â·ÃƒÂÃ‚Â° ÃƒÂÃ‚Â³ÃƒÂÃ‚ÂµÃƒÂÃ‚ÂºÃƒâ€˜Ã¢â‚¬Å¡ÃƒÂÃ‚Â°Ãƒâ€˜Ã¢â€šÂ¬</uk>
-            <ru>ÃƒÂÃ¢â‚¬â„¢Ãƒâ€˜Ã¢â‚¬Â¹ÃƒÂÃ‚Â±Ãƒâ€˜Ã¢â€šÂ¬ÃƒÂÃ‚Â°Ãƒâ€˜Ã¢â‚¬Å¡Ãƒâ€˜Ã…â€™ Ãƒâ€˜Ã¢â€šÂ¬ÃƒÂÃ‚Â°Ãƒâ€˜Ã‚ÂÃƒâ€˜Ã¢â‚¬Â¡ÃƒÂÃ‚ÂµÃƒâ€˜Ã¢â‚¬Å¡ Ãƒâ€˜Ã¢â€šÂ¬ÃƒÂÃ‚Â°Ãƒâ€˜Ã‚ÂÃƒâ€˜Ã¢â‚¬Â¦ÃƒÂÃ‚Â¾ÃƒÂÃ‚Â´ÃƒÂÃ‚Â¾ÃƒÂÃ‚Â²: ÃƒÂÃ‚Â¿ÃƒÂÃ‚Â¾Ãƒâ€˜Ã¢â‚¬Â¡ÃƒÂÃ‚Â°Ãƒâ€˜Ã‚ÂÃƒÂÃ‚Â¾ÃƒÂÃ‚Â²ÃƒÂÃ‚Â¾ ÃƒÂÃ‚Â¸ÃƒÂÃ‚Â»ÃƒÂÃ‚Â¸ ÃƒÂÃ‚Â·ÃƒÂÃ‚Â° ÃƒÂÃ‚Â³ÃƒÂÃ‚ÂµÃƒÂÃ‚ÂºÃƒâ€˜Ã¢â‚¬Å¡ÃƒÂÃ‚Â°Ãƒâ€˜Ã¢â€šÂ¬</ru>
+            <cz>Vyberte vÃƒÂ½poÃ„Âet nÃƒÂ¡kladÃ…Â¯: hodinovÃƒÂ½ nebo na hektar</cz>
+            <br>Escolher cÃƒÂ¡lculo de custos: por hora ou por hectare</br>
+            <uk>Ãâ€™ÃÂ¸ÃÂ±ÃÂµÃ‘â‚¬Ã‘â€“Ã‘â€šÃ‘Å’ Ã‘â‚¬ÃÂ¾ÃÂ·Ã‘â‚¬ÃÂ°Ã‘â€¦Ã‘Æ’ÃÂ½ÃÂ¾ÃÂº ÃÂ²ÃÂ¸Ã‘â€šÃ‘â‚¬ÃÂ°Ã‘â€š: ÃÂ¿ÃÂ¾ÃÂ³ÃÂ¾ÃÂ´ÃÂ¸ÃÂ½ÃÂ½ÃÂ¾ ÃÂ°ÃÂ±ÃÂ¾ ÃÂ·ÃÂ° ÃÂ³ÃÂµÃÂºÃ‘â€šÃÂ°Ã‘â‚¬</uk>
+            <ru>Ãâ€™Ã‘â€¹ÃÂ±Ã‘â‚¬ÃÂ°Ã‘â€šÃ‘Å’ Ã‘â‚¬ÃÂ°Ã‘ÂÃ‘â€¡ÃÂµÃ‘â€š Ã‘â‚¬ÃÂ°Ã‘ÂÃ‘â€¦ÃÂ¾ÃÂ´ÃÂ¾ÃÂ²: ÃÂ¿ÃÂ¾Ã‘â€¡ÃÂ°Ã‘ÂÃÂ¾ÃÂ²ÃÂ¾ ÃÂ¸ÃÂ»ÃÂ¸ ÃÂ·ÃÂ° ÃÂ³ÃÂµÃÂºÃ‘â€šÃÂ°Ã‘â‚¬</ru>
         
-            <da>VÃƒÆ’Ã‚Â¦lg beregningsmetode for omkostninger: timebaseret eller pr. hektar</da>
+            <da>VÃƒÂ¦lg beregningsmetode for omkostninger: timebaseret eller pr. hektar</da>
         </text>
         
         <text name="wc_costmode_1">
             <en>Hourly ($/h)</en>
-            <de>StÃƒÆ’Ã‚Â¼ndlich ($/h)</de>
+            <de>StÃƒÂ¼ndlich ($/h)</de>
             <fr>Horaire ($/h)</fr>
             <pl>Godzinowe ($/h)</pl>
             <es>Por hora ($/h)</es>
             <it>Orario ($/h)</it>
-            <cz>HodinovÃƒÆ’Ã‚Â© ($/h)</cz>
+            <cz>HodinovÃƒÂ© ($/h)</cz>
             <br>Por hora ($/h)</br>
-            <uk>ÃƒÂÃ…Â¸ÃƒÂÃ‚Â¾ÃƒÂÃ‚Â³ÃƒÂÃ‚Â¾ÃƒÂÃ‚Â´ÃƒÂÃ‚Â¸ÃƒÂÃ‚Â½ÃƒÂÃ‚Â½ÃƒÂÃ‚Â¾ ($/ÃƒÂÃ‚Â³ÃƒÂÃ‚Â¾ÃƒÂÃ‚Â´)</uk>
-            <ru>ÃƒÂÃ…Â¸ÃƒÂÃ‚Â¾Ãƒâ€˜Ã¢â‚¬Â¡ÃƒÂÃ‚Â°Ãƒâ€˜Ã‚ÂÃƒÂÃ‚Â¾ÃƒÂÃ‚Â²ÃƒÂÃ‚Â¾ ($/Ãƒâ€˜Ã¢â‚¬Â¡)</ru>
+            <uk>ÃÅ¸ÃÂ¾ÃÂ³ÃÂ¾ÃÂ´ÃÂ¸ÃÂ½ÃÂ½ÃÂ¾ ($/ÃÂ³ÃÂ¾ÃÂ´)</uk>
+            <ru>ÃÅ¸ÃÂ¾Ã‘â€¡ÃÂ°Ã‘ÂÃÂ¾ÃÂ²ÃÂ¾ ($/Ã‘â€¡)</ru>
         
             <da>Timebaseret ($/t)</da>
         </text>
@@ -165,12 +165,12 @@
             <de>Pro Hektar ($/ha)</de>
             <fr>Par hectare ($/ha)</fr>
             <pl>Za hektar ($/ha)</pl>
-            <es>Por hectÃƒÆ’Ã‚Â¡rea ($/ha)</es>
+            <es>Por hectÃƒÂ¡rea ($/ha)</es>
             <it>Per ettaro ($/ha)</it>
             <cz>Na hektar ($/ha)</cz>
             <br>Por hectare ($/ha)</br>
-            <uk>ÃƒÂÃ¢â‚¬â€ÃƒÂÃ‚Â° ÃƒÂÃ‚Â³ÃƒÂÃ‚ÂµÃƒÂÃ‚ÂºÃƒâ€˜Ã¢â‚¬Å¡ÃƒÂÃ‚Â°Ãƒâ€˜Ã¢â€šÂ¬ ($/ÃƒÂÃ‚Â³ÃƒÂÃ‚Â°)</uk>
-            <ru>ÃƒÂÃ¢â‚¬â€ÃƒÂÃ‚Â° ÃƒÂÃ‚Â³ÃƒÂÃ‚ÂµÃƒÂÃ‚ÂºÃƒâ€˜Ã¢â‚¬Å¡ÃƒÂÃ‚Â°Ãƒâ€˜Ã¢â€šÂ¬ ($/ÃƒÂÃ‚Â³ÃƒÂÃ‚Â°)</ru>
+            <uk>Ãâ€”ÃÂ° ÃÂ³ÃÂµÃÂºÃ‘â€šÃÂ°Ã‘â‚¬ ($/ÃÂ³ÃÂ°)</uk>
+            <ru>Ãâ€”ÃÂ° ÃÂ³ÃÂµÃÂºÃ‘â€šÃÂ°Ã‘â‚¬ ($/ÃÂ³ÃÂ°)</ru>
         
             <da>Pr. hektar ($/ha)</da>
         </text>
@@ -179,31 +179,31 @@
             <en>Monthly Salary</en>
             <de>Monatliches Gehalt</de>
             <fr>Salaire Mensuel</fr>
-            <pl>MiesiÃƒâ€žÃ¢â€žÂ¢czne Wynagrodzenie</pl>
+            <pl>MiesiÃ„â„¢czne Wynagrodzenie</pl>
             <es>Salario Mensual</es>
             <it>Stipendio Mensile</it>
-            <cz>MÃƒâ€žÃ¢â‚¬ÂºsÃƒÆ’Ã‚Â­Ãƒâ€žÃ‚ÂnÃƒÆ’Ã‚Â­ plat</cz>
-            <br>SalÃƒÆ’Ã‚Â¡rio Mensal</br>
-            <uk>ÃƒÂÃ‚Â©ÃƒÂÃ‚Â¾ÃƒÂÃ‚Â¼Ãƒâ€˜Ã¢â‚¬â€œÃƒâ€˜Ã‚ÂÃƒâ€˜Ã‚ÂÃƒâ€˜Ã¢â‚¬Â¡ÃƒÂÃ‚Â½ÃƒÂÃ‚Â° ÃƒÂÃ‚Â·ÃƒÂÃ‚Â°Ãƒâ€˜Ã¢â€šÂ¬ÃƒÂÃ‚Â¾ÃƒÂÃ‚Â±Ãƒâ€˜Ã¢â‚¬â€œÃƒâ€˜Ã¢â‚¬Å¡ÃƒÂÃ‚Â½ÃƒÂÃ‚Â° ÃƒÂÃ‚Â¿ÃƒÂÃ‚Â»ÃƒÂÃ‚Â°Ãƒâ€˜Ã¢â‚¬Å¡ÃƒÂÃ‚Â°</uk>
-            <ru>ÃƒÂÃ¢â‚¬Â¢ÃƒÂÃ‚Â¶ÃƒÂÃ‚ÂµÃƒÂÃ‚Â¼ÃƒÂÃ‚ÂµÃƒâ€˜Ã‚ÂÃƒâ€˜Ã‚ÂÃƒâ€˜Ã¢â‚¬Â¡ÃƒÂÃ‚Â½ÃƒÂÃ‚Â°Ãƒâ€˜Ã‚Â ÃƒÂÃ‚Â·ÃƒÂÃ‚Â°Ãƒâ€˜Ã¢â€šÂ¬ÃƒÂÃ‚Â¿ÃƒÂÃ‚Â»ÃƒÂÃ‚Â°Ãƒâ€˜Ã¢â‚¬Å¡ÃƒÂÃ‚Â°</ru>
+            <cz>MÃ„â€ºsÃƒÂ­Ã„ÂnÃƒÂ­ plat</cz>
+            <br>SalÃƒÂ¡rio Mensal</br>
+            <uk>ÃÂ©ÃÂ¾ÃÂ¼Ã‘â€“Ã‘ÂÃ‘ÂÃ‘â€¡ÃÂ½ÃÂ° ÃÂ·ÃÂ°Ã‘â‚¬ÃÂ¾ÃÂ±Ã‘â€“Ã‘â€šÃÂ½ÃÂ° ÃÂ¿ÃÂ»ÃÂ°Ã‘â€šÃÂ°</uk>
+            <ru>Ãâ€¢ÃÂ¶ÃÂµÃÂ¼ÃÂµÃ‘ÂÃ‘ÂÃ‘â€¡ÃÂ½ÃÂ°Ã‘Â ÃÂ·ÃÂ°Ã‘â‚¬ÃÂ¿ÃÂ»ÃÂ°Ã‘â€šÃÂ°</ru>
         
-            <da>MÃƒÆ’Ã‚Â¥nedslÃƒÆ’Ã‚Â¸n</da>
+            <da>MÃƒÂ¥nedslÃƒÂ¸n</da>
         </text>
 
         
         <text name="wc_difficulty_long">
             <en>Set base wage rate: Low=$15/h, Medium=$25/h, High=$40/h</en>
             <de>Grundlohnsatz festlegen: Niedrig=15$/h, Mittel=25$/h, Hoch=40$/h</de>
-            <fr>DÃƒÆ’Ã‚Â©finir le taux de salaire de base : Bas=15$/h, Moyen=25$/h, ÃƒÆ’Ã¢â‚¬Â°levÃƒÆ’Ã‚Â©=40$/h</fr>
-            <pl>Ustaw podstawowÃƒâ€žÃ¢â‚¬Â¦ stawkÃƒâ€žÃ¢â€žÂ¢: Niska=15$/h, Ãƒâ€¦Ã…Â¡rednia=25$/h, Wysoka=40$/h</pl>
+            <fr>DÃƒÂ©finir le taux de salaire de base : Bas=15$/h, Moyen=25$/h, Ãƒâ€°levÃƒÂ©=40$/h</fr>
+            <pl>Ustaw podstawowÃ„â€¦ stawkÃ„â„¢: Niska=15$/h, Ã…Å¡rednia=25$/h, Wysoka=40$/h</pl>
             <es>Establecer tasa salarial base: Baja=15$/h, Media=25$/h, Alta=40$/h</es>
             <it>Imposta tariffa base: Bassa=15$/h, Media=25$/h, Alta=40$/h</it>
-            <cz>Nastavit zÃƒÆ’Ã‚Â¡kladnÃƒÆ’Ã‚Â­ sazbu: NÃƒÆ’Ã‚Â­zkÃƒÆ’Ã‚Â¡=15$/h, StÃƒâ€¦Ã¢â€žÂ¢ednÃƒÆ’Ã‚Â­=25$/h, VysokÃƒÆ’Ã‚Â¡=40$/h</cz>
-            <br>Definir taxa salarial base: Baixa=15$/h, MÃƒÆ’Ã‚Â©dia=25$/h, Alta=40$/h</br>
-            <uk>ÃƒÂÃ¢â‚¬â„¢Ãƒâ€˜Ã‚ÂÃƒâ€˜Ã¢â‚¬Å¡ÃƒÂÃ‚Â°ÃƒÂÃ‚Â½ÃƒÂÃ‚Â¾ÃƒÂÃ‚Â²ÃƒÂÃ‚Â¸Ãƒâ€˜Ã¢â‚¬Å¡ÃƒÂÃ‚Â¸ ÃƒÂÃ‚Â±ÃƒÂÃ‚Â°ÃƒÂÃ‚Â·ÃƒÂÃ‚Â¾ÃƒÂÃ‚Â²Ãƒâ€˜Ã†â€™ Ãƒâ€˜Ã‚ÂÃƒâ€˜Ã¢â‚¬Å¡ÃƒÂÃ‚Â°ÃƒÂÃ‚Â²ÃƒÂÃ‚ÂºÃƒâ€˜Ã†â€™: ÃƒÂÃ‚ÂÃƒÂÃ‚Â¸ÃƒÂÃ‚Â·Ãƒâ€˜Ã…â€™ÃƒÂÃ‚ÂºÃƒÂÃ‚Â°=15$/ÃƒÂÃ‚Â³ÃƒÂÃ‚Â¾ÃƒÂÃ‚Â´, ÃƒÂÃ‚Â¡ÃƒÂÃ‚ÂµÃƒâ€˜Ã¢â€šÂ¬ÃƒÂÃ‚ÂµÃƒÂÃ‚Â´ÃƒÂÃ‚Â½Ãƒâ€˜Ã‚Â=25$/ÃƒÂÃ‚Â³ÃƒÂÃ‚Â¾ÃƒÂÃ‚Â´, ÃƒÂÃ¢â‚¬â„¢ÃƒÂÃ‚Â¸Ãƒâ€˜Ã‚ÂÃƒÂÃ‚Â¾ÃƒÂÃ‚ÂºÃƒÂÃ‚Â°=40$/ÃƒÂÃ‚Â³ÃƒÂÃ‚Â¾ÃƒÂÃ‚Â´</uk>
-            <ru>ÃƒÂÃ‚Â£Ãƒâ€˜Ã‚ÂÃƒâ€˜Ã¢â‚¬Å¡ÃƒÂÃ‚Â°ÃƒÂÃ‚Â½ÃƒÂÃ‚Â¾ÃƒÂÃ‚Â²ÃƒÂÃ‚Â¸Ãƒâ€˜Ã¢â‚¬Å¡Ãƒâ€˜Ã…â€™ ÃƒÂÃ‚Â±ÃƒÂÃ‚Â°ÃƒÂÃ‚Â·ÃƒÂÃ‚Â¾ÃƒÂÃ‚Â²Ãƒâ€˜Ã†â€™Ãƒâ€˜Ã…Â½ Ãƒâ€˜Ã‚ÂÃƒâ€˜Ã¢â‚¬Å¡ÃƒÂÃ‚Â°ÃƒÂÃ‚Â²ÃƒÂÃ‚ÂºÃƒâ€˜Ã†â€™: ÃƒÂÃ‚ÂÃƒÂÃ‚Â¸ÃƒÂÃ‚Â·ÃƒÂÃ‚ÂºÃƒÂÃ‚Â°Ãƒâ€˜Ã‚Â=15$/Ãƒâ€˜Ã¢â‚¬Â¡, ÃƒÂÃ‚Â¡Ãƒâ€˜Ã¢â€šÂ¬ÃƒÂÃ‚ÂµÃƒÂÃ‚Â´ÃƒÂÃ‚Â½Ãƒâ€˜Ã‚ÂÃƒâ€˜Ã‚Â=25$/Ãƒâ€˜Ã¢â‚¬Â¡, ÃƒÂÃ¢â‚¬â„¢Ãƒâ€˜Ã¢â‚¬Â¹Ãƒâ€˜Ã‚ÂÃƒÂÃ‚Â¾ÃƒÂÃ‚ÂºÃƒÂÃ‚Â°Ãƒâ€˜Ã‚Â=40$/Ãƒâ€˜Ã¢â‚¬Â¡</ru>
+            <cz>Nastavit zÃƒÂ¡kladnÃƒÂ­ sazbu: NÃƒÂ­zkÃƒÂ¡=15$/h, StÃ…â„¢ednÃƒÂ­=25$/h, VysokÃƒÂ¡=40$/h</cz>
+            <br>Definir taxa salarial base: Baixa=15$/h, MÃƒÂ©dia=25$/h, Alta=40$/h</br>
+            <uk>Ãâ€™Ã‘ÂÃ‘â€šÃÂ°ÃÂ½ÃÂ¾ÃÂ²ÃÂ¸Ã‘â€šÃÂ¸ ÃÂ±ÃÂ°ÃÂ·ÃÂ¾ÃÂ²Ã‘Æ’ Ã‘ÂÃ‘â€šÃÂ°ÃÂ²ÃÂºÃ‘Æ’: ÃÂÃÂ¸ÃÂ·Ã‘Å’ÃÂºÃÂ°=15$/ÃÂ³ÃÂ¾ÃÂ´, ÃÂ¡ÃÂµÃ‘â‚¬ÃÂµÃÂ´ÃÂ½Ã‘Â=25$/ÃÂ³ÃÂ¾ÃÂ´, Ãâ€™ÃÂ¸Ã‘ÂÃÂ¾ÃÂºÃÂ°=40$/ÃÂ³ÃÂ¾ÃÂ´</uk>
+            <ru>ÃÂ£Ã‘ÂÃ‘â€šÃÂ°ÃÂ½ÃÂ¾ÃÂ²ÃÂ¸Ã‘â€šÃ‘Å’ ÃÂ±ÃÂ°ÃÂ·ÃÂ¾ÃÂ²Ã‘Æ’Ã‘Å½ Ã‘ÂÃ‘â€šÃÂ°ÃÂ²ÃÂºÃ‘Æ’: ÃÂÃÂ¸ÃÂ·ÃÂºÃÂ°Ã‘Â=15$/Ã‘â€¡, ÃÂ¡Ã‘â‚¬ÃÂµÃÂ´ÃÂ½Ã‘ÂÃ‘Â=25$/Ã‘â€¡, Ãâ€™Ã‘â€¹Ã‘ÂÃÂ¾ÃÂºÃÂ°Ã‘Â=40$/Ã‘â€¡</ru>
         
-            <da>Angiv basislÃƒÆ’Ã‚Â¸nsats: Lav=$15/t, Mellem=$25/t, HÃƒÆ’Ã‚Â¸j=$40/t</da>
+            <da>Angiv basislÃƒÂ¸nsats: Lav=$15/t, Mellem=$25/t, HÃƒÂ¸j=$40/t</da>
         </text>
         
         <text name="wc_diff_1">
@@ -213,10 +213,10 @@
             <pl>Niska (15$/h)</pl>
             <es>Baja (15$/h)</es>
             <it>Bassa (15$/h)</it>
-            <cz>NÃƒÆ’Ã‚Â­zkÃƒÆ’Ã‚Â¡ (15$/h)</cz>
+            <cz>NÃƒÂ­zkÃƒÂ¡ (15$/h)</cz>
             <br>Baixa (15$/h)</br>
-            <uk>ÃƒÂÃ‚ÂÃƒÂÃ‚Â¸ÃƒÂÃ‚Â·Ãƒâ€˜Ã…â€™ÃƒÂÃ‚ÂºÃƒÂÃ‚Â° (15$/ÃƒÂÃ‚Â³ÃƒÂÃ‚Â¾ÃƒÂÃ‚Â´)</uk>
-            <ru>ÃƒÂÃ‚ÂÃƒÂÃ‚Â¸ÃƒÂÃ‚Â·ÃƒÂÃ‚ÂºÃƒÂÃ‚Â°Ãƒâ€˜Ã‚Â (15$/Ãƒâ€˜Ã¢â‚¬Â¡)</ru>
+            <uk>ÃÂÃÂ¸ÃÂ·Ã‘Å’ÃÂºÃÂ° (15$/ÃÂ³ÃÂ¾ÃÂ´)</uk>
+            <ru>ÃÂÃÂ¸ÃÂ·ÃÂºÃÂ°Ã‘Â (15$/Ã‘â€¡)</ru>
         
             <da>Lav ($15/t)</da>
         </text>
@@ -225,13 +225,13 @@
             <en>Medium ($25/h)</en>
             <de>Mittel (25$/h)</de>
             <fr>Moyen (25$/h)</fr>
-            <pl>Ãƒâ€¦Ã…Â¡rednia (25$/h)</pl>
+            <pl>Ã…Å¡rednia (25$/h)</pl>
             <es>Media (25$/h)</es>
             <it>Media (25$/h)</it>
-            <cz>StÃƒâ€¦Ã¢â€žÂ¢ednÃƒÆ’Ã‚Â­ (25$/h)</cz>
-            <br>MÃƒÆ’Ã‚Â©dia (25$/h)</br>
-            <uk>ÃƒÂÃ‚Â¡ÃƒÂÃ‚ÂµÃƒâ€˜Ã¢â€šÂ¬ÃƒÂÃ‚ÂµÃƒÂÃ‚Â´ÃƒÂÃ‚Â½Ãƒâ€˜Ã‚Â (25$/ÃƒÂÃ‚Â³ÃƒÂÃ‚Â¾ÃƒÂÃ‚Â´)</uk>
-            <ru>ÃƒÂÃ‚Â¡Ãƒâ€˜Ã¢â€šÂ¬ÃƒÂÃ‚ÂµÃƒÂÃ‚Â´ÃƒÂÃ‚Â½Ãƒâ€˜Ã‚ÂÃƒâ€˜Ã‚Â (25$/Ãƒâ€˜Ã¢â‚¬Â¡)</ru>
+            <cz>StÃ…â„¢ednÃƒÂ­ (25$/h)</cz>
+            <br>MÃƒÂ©dia (25$/h)</br>
+            <uk>ÃÂ¡ÃÂµÃ‘â‚¬ÃÂµÃÂ´ÃÂ½Ã‘Â (25$/ÃÂ³ÃÂ¾ÃÂ´)</uk>
+            <ru>ÃÂ¡Ã‘â‚¬ÃÂµÃÂ´ÃÂ½Ã‘ÂÃ‘Â (25$/Ã‘â€¡)</ru>
         
             <da>Mellem ($25/t)</da>
         </text>
@@ -239,16 +239,16 @@
         <text name="wc_diff_3">
             <en>High ($40/h)</en>
             <de>Hoch (40$/h)</de>
-            <fr>ÃƒÆ’Ã¢â‚¬Â°levÃƒÆ’Ã‚Â© (40$/h)</fr>
+            <fr>Ãƒâ€°levÃƒÂ© (40$/h)</fr>
             <pl>Wysoka (40$/h)</pl>
             <es>Alta (40$/h)</es>
             <it>Alta (40$/h)</it>
-            <cz>VysokÃƒÆ’Ã‚Â¡ (40$/h)</cz>
+            <cz>VysokÃƒÂ¡ (40$/h)</cz>
             <br>Alta (40$/h)</br>
-            <uk>ÃƒÂÃ¢â‚¬â„¢ÃƒÂÃ‚Â¸Ãƒâ€˜Ã‚ÂÃƒÂÃ‚Â¾ÃƒÂÃ‚ÂºÃƒÂÃ‚Â° (40$/ÃƒÂÃ‚Â³ÃƒÂÃ‚Â¾ÃƒÂÃ‚Â´)</uk>
-            <ru>ÃƒÂÃ¢â‚¬â„¢Ãƒâ€˜Ã¢â‚¬Â¹Ãƒâ€˜Ã‚ÂÃƒÂÃ‚Â¾ÃƒÂÃ‚ÂºÃƒÂÃ‚Â°Ãƒâ€˜Ã‚Â (40$/Ãƒâ€˜Ã¢â‚¬Â¡)</ru>
+            <uk>Ãâ€™ÃÂ¸Ã‘ÂÃÂ¾ÃÂºÃÂ° (40$/ÃÂ³ÃÂ¾ÃÂ´)</uk>
+            <ru>Ãâ€™Ã‘â€¹Ã‘ÂÃÂ¾ÃÂºÃÂ°Ã‘Â (40$/Ã‘â€¡)</ru>
         
-            <da>HÃƒÆ’Ã‚Â¸j ($40/t)</da>
+            <da>HÃƒÂ¸j ($40/t)</da>
         </text>
         
         <text name="wc_notifications_short">
@@ -258,10 +258,10 @@
             <pl>Powiadomienia</pl>
             <es>Notificaciones</es>
             <it>Notifiche</it>
-            <cz>UpozornÃƒâ€žÃ¢â‚¬ÂºnÃƒÆ’Ã‚Â­</cz>
-            <br>NotificaÃƒÆ’Ã‚Â§ÃƒÆ’Ã‚Âµes</br>
-            <uk>ÃƒÂÃ‚Â¡ÃƒÂÃ‚Â¿ÃƒÂÃ‚Â¾ÃƒÂÃ‚Â²Ãƒâ€˜Ã¢â‚¬â€œÃƒâ€˜Ã¢â‚¬Â°ÃƒÂÃ‚ÂµÃƒÂÃ‚Â½ÃƒÂÃ‚Â½Ãƒâ€˜Ã‚Â</uk>
-            <ru>ÃƒÂÃ‚Â£ÃƒÂÃ‚Â²ÃƒÂÃ‚ÂµÃƒÂÃ‚Â´ÃƒÂÃ‚Â¾ÃƒÂÃ‚Â¼ÃƒÂÃ‚Â»ÃƒÂÃ‚ÂµÃƒÂÃ‚Â½ÃƒÂÃ‚Â¸Ãƒâ€˜Ã‚Â</ru>
+            <cz>UpozornÃ„â€ºnÃƒÂ­</cz>
+            <br>NotificaÃƒÂ§ÃƒÂµes</br>
+            <uk>ÃÂ¡ÃÂ¿ÃÂ¾ÃÂ²Ã‘â€“Ã‘â€°ÃÂµÃÂ½ÃÂ½Ã‘Â</uk>
+            <ru>ÃÂ£ÃÂ²ÃÂµÃÂ´ÃÂ¾ÃÂ¼ÃÂ»ÃÂµÃÂ½ÃÂ¸Ã‘Â</ru>
         
             <da>Notifikationer</da>
         </text>
@@ -269,29 +269,29 @@
         <text name="wc_notifications_long">
             <en>Enable/disable wage payment notifications</en>
             <de>Lohnzahlungsbenachrichtigungen ein-/ausschalten</de>
-            <fr>Activer/dÃƒÆ’Ã‚Â©sactiver les notifications de paiement des salaires</fr>
-            <pl>WÃƒâ€¦Ã¢â‚¬Å¡Ãƒâ€žÃ¢â‚¬Â¦cz/wyÃƒâ€¦Ã¢â‚¬Å¡Ãƒâ€žÃ¢â‚¬Â¦cz powiadomienia o wypÃƒâ€¦Ã¢â‚¬Å¡atach wynagrodzeÃƒâ€¦Ã¢â‚¬Å¾</pl>
+            <fr>Activer/dÃƒÂ©sactiver les notifications de paiement des salaires</fr>
+            <pl>WÃ…â€šÃ„â€¦cz/wyÃ…â€šÃ„â€¦cz powiadomienia o wypÃ…â€šatach wynagrodzeÃ…â€ž</pl>
             <es>Activar/desactivar notificaciones de pago de salarios</es>
             <it>Attiva/disattiva notifiche pagamento salari</it>
-            <cz>Povolit/zakÃƒÆ’Ã‚Â¡zat upozornÃƒâ€žÃ¢â‚¬ÂºnÃƒÆ’Ã‚Â­ na vÃƒÆ’Ã‚Â½platu mezd</cz>
-            <br>Ativar/desativar notificaÃƒÆ’Ã‚Â§ÃƒÆ’Ã‚Âµes de pagamento de salÃƒÆ’Ã‚Â¡rios</br>
-            <uk>ÃƒÂÃ‚Â£ÃƒÂÃ‚Â²Ãƒâ€˜Ã¢â‚¬â€œÃƒÂÃ‚Â¼ÃƒÂÃ‚ÂºÃƒÂÃ‚Â½Ãƒâ€˜Ã†â€™Ãƒâ€˜Ã¢â‚¬Å¡ÃƒÂÃ‚Â¸/ÃƒÂÃ‚Â²ÃƒÂÃ‚Â¸ÃƒÂÃ‚Â¼ÃƒÂÃ‚ÂºÃƒÂÃ‚Â½Ãƒâ€˜Ã†â€™Ãƒâ€˜Ã¢â‚¬Å¡ÃƒÂÃ‚Â¸ Ãƒâ€˜Ã‚ÂÃƒÂÃ‚Â¿ÃƒÂÃ‚Â¾ÃƒÂÃ‚Â²Ãƒâ€˜Ã¢â‚¬â€œÃƒâ€˜Ã¢â‚¬Â°ÃƒÂÃ‚ÂµÃƒÂÃ‚Â½ÃƒÂÃ‚Â½Ãƒâ€˜Ã‚Â ÃƒÂÃ‚Â¿Ãƒâ€˜Ã¢â€šÂ¬ÃƒÂÃ‚Â¾ ÃƒÂÃ‚Â²ÃƒÂÃ‚Â¸ÃƒÂÃ‚Â¿ÃƒÂÃ‚Â»ÃƒÂÃ‚Â°Ãƒâ€˜Ã¢â‚¬Å¡Ãƒâ€˜Ã†â€™ ÃƒÂÃ‚Â·ÃƒÂÃ‚Â°Ãƒâ€˜Ã¢â€šÂ¬ÃƒÂÃ‚Â¾ÃƒÂÃ‚Â±Ãƒâ€˜Ã¢â‚¬â€œÃƒâ€˜Ã¢â‚¬Å¡ÃƒÂÃ‚Â½ÃƒÂÃ‚Â¾Ãƒâ€˜Ã¢â‚¬â€ ÃƒÂÃ‚Â¿ÃƒÂÃ‚Â»ÃƒÂÃ‚Â°Ãƒâ€˜Ã¢â‚¬Å¡ÃƒÂÃ‚Â¸</uk>
-            <ru>ÃƒÂÃ¢â‚¬â„¢ÃƒÂÃ‚ÂºÃƒÂÃ‚Â»Ãƒâ€˜Ã…Â½Ãƒâ€˜Ã¢â‚¬Â¡ÃƒÂÃ‚Â¸Ãƒâ€˜Ã¢â‚¬Å¡Ãƒâ€˜Ã…â€™/ÃƒÂÃ‚Â²Ãƒâ€˜Ã¢â‚¬Â¹ÃƒÂÃ‚ÂºÃƒÂÃ‚Â»Ãƒâ€˜Ã…Â½Ãƒâ€˜Ã¢â‚¬Â¡ÃƒÂÃ‚Â¸Ãƒâ€˜Ã¢â‚¬Å¡Ãƒâ€˜Ã…â€™ Ãƒâ€˜Ã†â€™ÃƒÂÃ‚Â²ÃƒÂÃ‚ÂµÃƒÂÃ‚Â´ÃƒÂÃ‚Â¾ÃƒÂÃ‚Â¼ÃƒÂÃ‚Â»ÃƒÂÃ‚ÂµÃƒÂÃ‚Â½ÃƒÂÃ‚Â¸Ãƒâ€˜Ã‚Â ÃƒÂÃ‚Â¾ ÃƒÂÃ‚Â²Ãƒâ€˜Ã¢â‚¬Â¹ÃƒÂÃ‚Â¿ÃƒÂÃ‚Â»ÃƒÂÃ‚Â°Ãƒâ€˜Ã¢â‚¬Å¡ÃƒÂÃ‚Âµ ÃƒÂÃ‚Â·ÃƒÂÃ‚Â°Ãƒâ€˜Ã¢â€šÂ¬ÃƒÂÃ‚Â°ÃƒÂÃ‚Â±ÃƒÂÃ‚Â¾Ãƒâ€˜Ã¢â‚¬Å¡ÃƒÂÃ‚Â½ÃƒÂÃ‚Â¾ÃƒÂÃ‚Â¹ ÃƒÂÃ‚Â¿ÃƒÂÃ‚Â»ÃƒÂÃ‚Â°Ãƒâ€˜Ã¢â‚¬Å¡Ãƒâ€˜Ã¢â‚¬Â¹</ru>
+            <cz>Povolit/zakÃƒÂ¡zat upozornÃ„â€ºnÃƒÂ­ na vÃƒÂ½platu mezd</cz>
+            <br>Ativar/desativar notificaÃƒÂ§ÃƒÂµes de pagamento de salÃƒÂ¡rios</br>
+            <uk>ÃÂ£ÃÂ²Ã‘â€“ÃÂ¼ÃÂºÃÂ½Ã‘Æ’Ã‘â€šÃÂ¸/ÃÂ²ÃÂ¸ÃÂ¼ÃÂºÃÂ½Ã‘Æ’Ã‘â€šÃÂ¸ Ã‘ÂÃÂ¿ÃÂ¾ÃÂ²Ã‘â€“Ã‘â€°ÃÂµÃÂ½ÃÂ½Ã‘Â ÃÂ¿Ã‘â‚¬ÃÂ¾ ÃÂ²ÃÂ¸ÃÂ¿ÃÂ»ÃÂ°Ã‘â€šÃ‘Æ’ ÃÂ·ÃÂ°Ã‘â‚¬ÃÂ¾ÃÂ±Ã‘â€“Ã‘â€šÃÂ½ÃÂ¾Ã‘â€” ÃÂ¿ÃÂ»ÃÂ°Ã‘â€šÃÂ¸</uk>
+            <ru>Ãâ€™ÃÂºÃÂ»Ã‘Å½Ã‘â€¡ÃÂ¸Ã‘â€šÃ‘Å’/ÃÂ²Ã‘â€¹ÃÂºÃÂ»Ã‘Å½Ã‘â€¡ÃÂ¸Ã‘â€šÃ‘Å’ Ã‘Æ’ÃÂ²ÃÂµÃÂ´ÃÂ¾ÃÂ¼ÃÂ»ÃÂµÃÂ½ÃÂ¸Ã‘Â ÃÂ¾ ÃÂ²Ã‘â€¹ÃÂ¿ÃÂ»ÃÂ°Ã‘â€šÃÂµ ÃÂ·ÃÂ°Ã‘â‚¬ÃÂ°ÃÂ±ÃÂ¾Ã‘â€šÃÂ½ÃÂ¾ÃÂ¹ ÃÂ¿ÃÂ»ÃÂ°Ã‘â€šÃ‘â€¹</ru>
         
-            <da>SlÃƒÆ’Ã‚Â¥ notifikationer om lÃƒÆ’Ã‚Â¸nudbetalinger til/fra</da>
+            <da>SlÃƒÂ¥ notifikationer om lÃƒÂ¸nudbetalinger til/fra</da>
         </text>
         
         <text name="wc_customrate_short">
             <en>Custom Rate</en>
             <de>Benutzerdefinierte Rate</de>
-            <fr>Taux personnalisÃƒÆ’Ã‚Â©</fr>
+            <fr>Taux personnalisÃƒÂ©</fr>
             <pl>Niestandardowa stawka</pl>
             <es>Tasa personalizada</es>
             <it>Tariffa personalizzata</it>
-            <cz>VlastnÃƒÆ’Ã‚Â­ sazba</cz>
+            <cz>VlastnÃƒÂ­ sazba</cz>
             <br>Taxa personalizada</br>
-            <uk>ÃƒÂÃ¢â‚¬â„¢ÃƒÂÃ‚Â»ÃƒÂÃ‚Â°Ãƒâ€˜Ã‚ÂÃƒÂÃ‚Â½ÃƒÂÃ‚Â° Ãƒâ€˜Ã‚ÂÃƒâ€˜Ã¢â‚¬Å¡ÃƒÂÃ‚Â°ÃƒÂÃ‚Â²ÃƒÂÃ‚ÂºÃƒÂÃ‚Â°</uk>
-            <ru>ÃƒÂÃ…Â¸ÃƒÂÃ‚Â¾ÃƒÂÃ‚Â»Ãƒâ€˜Ã…â€™ÃƒÂÃ‚Â·ÃƒÂÃ‚Â¾ÃƒÂÃ‚Â²ÃƒÂÃ‚Â°Ãƒâ€˜Ã¢â‚¬Å¡ÃƒÂÃ‚ÂµÃƒÂÃ‚Â»Ãƒâ€˜Ã…â€™Ãƒâ€˜Ã‚ÂÃƒÂÃ‚ÂºÃƒÂÃ‚Â°Ãƒâ€˜Ã‚Â Ãƒâ€˜Ã‚ÂÃƒâ€˜Ã¢â‚¬Å¡ÃƒÂÃ‚Â°ÃƒÂÃ‚Â²ÃƒÂÃ‚ÂºÃƒÂÃ‚Â°</ru>
+            <uk>Ãâ€™ÃÂ»ÃÂ°Ã‘ÂÃÂ½ÃÂ° Ã‘ÂÃ‘â€šÃÂ°ÃÂ²ÃÂºÃÂ°</uk>
+            <ru>ÃÅ¸ÃÂ¾ÃÂ»Ã‘Å’ÃÂ·ÃÂ¾ÃÂ²ÃÂ°Ã‘â€šÃÂµÃÂ»Ã‘Å’Ã‘ÂÃÂºÃÂ°Ã‘Â Ã‘ÂÃ‘â€šÃÂ°ÃÂ²ÃÂºÃÂ°</ru>
         
             <da>Brugerdefineret sats</da>
         </text>
@@ -299,34 +299,34 @@
         <text name="wc_customrate_long">
             <en>Set custom wage rate (0 = use wage level setting)</en>
             <de>Benutzerdefinierten Lohnsatz festlegen (0 = Lohnniveau verwenden)</de>
-            <fr>DÃƒÆ’Ã‚Â©finir le taux de salaire personnalisÃƒÆ’Ã‚Â© (0 = utiliser le niveau de salaire)</fr>
-            <pl>Ustaw niestandardowÃƒâ€žÃ¢â‚¬Â¦ stawkÃƒâ€žÃ¢â€žÂ¢ (0 = uÃƒâ€¦Ã‚Â¼yj ustawienia poziomu pÃƒâ€¦Ã¢â‚¬Å¡ac)</pl>
-            <es>Establecer tasa salarial personalizada (0 = usar configuraciÃƒÆ’Ã‚Â³n de nivel)</es>
+            <fr>DÃƒÂ©finir le taux de salaire personnalisÃƒÂ© (0 = utiliser le niveau de salaire)</fr>
+            <pl>Ustaw niestandardowÃ„â€¦ stawkÃ„â„¢ (0 = uÃ…Â¼yj ustawienia poziomu pÃ…â€šac)</pl>
+            <es>Establecer tasa salarial personalizada (0 = usar configuraciÃƒÂ³n de nivel)</es>
             <it>Imposta tariffa salariale personalizzata (0 = usa impostazione livello)</it>
-            <cz>Nastavit vlastnÃƒÆ’Ã‚Â­ mzdovou sazbu (0 = pouÃƒâ€¦Ã‚Â¾ÃƒÆ’Ã‚Â­t nastavenÃƒÆ’Ã‚Â­ ÃƒÆ’Ã‚ÂºrovnÃƒâ€žÃ¢â‚¬Âº)</cz>
-            <br>Definir taxa salarial personalizada (0 = usar configuraÃƒÆ’Ã‚Â§ÃƒÆ’Ã‚Â£o de nÃƒÆ’Ã‚Â­vel)</br>
-            <uk>ÃƒÂÃ¢â‚¬â„¢Ãƒâ€˜Ã‚ÂÃƒâ€˜Ã¢â‚¬Å¡ÃƒÂÃ‚Â°ÃƒÂÃ‚Â½ÃƒÂÃ‚Â¾ÃƒÂÃ‚Â²ÃƒÂÃ‚Â¸Ãƒâ€˜Ã¢â‚¬Å¡ÃƒÂÃ‚Â¸ ÃƒÂÃ‚Â²ÃƒÂÃ‚Â»ÃƒÂÃ‚Â°Ãƒâ€˜Ã‚ÂÃƒÂÃ‚Â½Ãƒâ€˜Ã†â€™ Ãƒâ€˜Ã‚ÂÃƒâ€˜Ã¢â‚¬Å¡ÃƒÂÃ‚Â°ÃƒÂÃ‚Â²ÃƒÂÃ‚ÂºÃƒâ€˜Ã†â€™ ÃƒÂÃ‚Â¾ÃƒÂÃ‚Â¿ÃƒÂÃ‚Â»ÃƒÂÃ‚Â°Ãƒâ€˜Ã¢â‚¬Å¡ÃƒÂÃ‚Â¸ (0 = ÃƒÂÃ‚Â²ÃƒÂÃ‚Â¸ÃƒÂÃ‚ÂºÃƒÂÃ‚Â¾Ãƒâ€˜Ã¢â€šÂ¬ÃƒÂÃ‚Â¸Ãƒâ€˜Ã‚ÂÃƒâ€˜Ã¢â‚¬Å¡ÃƒÂÃ‚Â¾ÃƒÂÃ‚Â²Ãƒâ€˜Ã†â€™ÃƒÂÃ‚Â²ÃƒÂÃ‚Â°Ãƒâ€˜Ã¢â‚¬Å¡ÃƒÂÃ‚Â¸ ÃƒÂÃ‚Â½ÃƒÂÃ‚Â°ÃƒÂÃ‚Â»ÃƒÂÃ‚Â°Ãƒâ€˜Ã‹â€ Ãƒâ€˜Ã¢â‚¬Å¡Ãƒâ€˜Ã†â€™ÃƒÂÃ‚Â²ÃƒÂÃ‚Â°ÃƒÂÃ‚Â½ÃƒÂÃ‚Â½Ãƒâ€˜Ã‚Â Ãƒâ€˜Ã¢â€šÂ¬Ãƒâ€˜Ã¢â‚¬â€œÃƒÂÃ‚Â²ÃƒÂÃ‚Â½Ãƒâ€˜Ã‚Â)</uk>
-            <ru>ÃƒÂÃ‚Â£Ãƒâ€˜Ã‚ÂÃƒâ€˜Ã¢â‚¬Å¡ÃƒÂÃ‚Â°ÃƒÂÃ‚Â½ÃƒÂÃ‚Â¾ÃƒÂÃ‚Â²ÃƒÂÃ‚Â¸Ãƒâ€˜Ã¢â‚¬Å¡Ãƒâ€˜Ã…â€™ ÃƒÂÃ‚Â¿ÃƒÂÃ‚Â¾ÃƒÂÃ‚Â»Ãƒâ€˜Ã…â€™ÃƒÂÃ‚Â·ÃƒÂÃ‚Â¾ÃƒÂÃ‚Â²ÃƒÂÃ‚Â°Ãƒâ€˜Ã¢â‚¬Å¡ÃƒÂÃ‚ÂµÃƒÂÃ‚Â»Ãƒâ€˜Ã…â€™Ãƒâ€˜Ã‚ÂÃƒÂÃ‚ÂºÃƒâ€˜Ã†â€™Ãƒâ€˜Ã…Â½ Ãƒâ€˜Ã‚ÂÃƒâ€˜Ã¢â‚¬Å¡ÃƒÂÃ‚Â°ÃƒÂÃ‚Â²ÃƒÂÃ‚ÂºÃƒâ€˜Ã†â€™ ÃƒÂÃ‚Â¾ÃƒÂÃ‚Â¿ÃƒÂÃ‚Â»ÃƒÂÃ‚Â°Ãƒâ€˜Ã¢â‚¬Å¡Ãƒâ€˜Ã¢â‚¬Â¹ (0 = ÃƒÂÃ‚Â¸Ãƒâ€˜Ã‚ÂÃƒÂÃ‚Â¿ÃƒÂÃ‚Â¾ÃƒÂÃ‚Â»Ãƒâ€˜Ã…â€™ÃƒÂÃ‚Â·ÃƒÂÃ‚Â¾ÃƒÂÃ‚Â²ÃƒÂÃ‚Â°Ãƒâ€˜Ã¢â‚¬Å¡Ãƒâ€˜Ã…â€™ ÃƒÂÃ‚Â½ÃƒÂÃ‚Â°Ãƒâ€˜Ã‚ÂÃƒâ€˜Ã¢â‚¬Å¡Ãƒâ€˜Ã¢â€šÂ¬ÃƒÂÃ‚Â¾ÃƒÂÃ‚Â¹ÃƒÂÃ‚ÂºÃƒâ€˜Ã†â€™ Ãƒâ€˜Ã†â€™Ãƒâ€˜Ã¢â€šÂ¬ÃƒÂÃ‚Â¾ÃƒÂÃ‚Â²ÃƒÂÃ‚Â½Ãƒâ€˜Ã‚Â)</ru>
+            <cz>Nastavit vlastnÃƒÂ­ mzdovou sazbu (0 = pouÃ…Â¾ÃƒÂ­t nastavenÃƒÂ­ ÃƒÂºrovnÃ„â€º)</cz>
+            <br>Definir taxa salarial personalizada (0 = usar configuraÃƒÂ§ÃƒÂ£o de nÃƒÂ­vel)</br>
+            <uk>Ãâ€™Ã‘ÂÃ‘â€šÃÂ°ÃÂ½ÃÂ¾ÃÂ²ÃÂ¸Ã‘â€šÃÂ¸ ÃÂ²ÃÂ»ÃÂ°Ã‘ÂÃÂ½Ã‘Æ’ Ã‘ÂÃ‘â€šÃÂ°ÃÂ²ÃÂºÃ‘Æ’ ÃÂ¾ÃÂ¿ÃÂ»ÃÂ°Ã‘â€šÃÂ¸ (0 = ÃÂ²ÃÂ¸ÃÂºÃÂ¾Ã‘â‚¬ÃÂ¸Ã‘ÂÃ‘â€šÃÂ¾ÃÂ²Ã‘Æ’ÃÂ²ÃÂ°Ã‘â€šÃÂ¸ ÃÂ½ÃÂ°ÃÂ»ÃÂ°Ã‘Ë†Ã‘â€šÃ‘Æ’ÃÂ²ÃÂ°ÃÂ½ÃÂ½Ã‘Â Ã‘â‚¬Ã‘â€“ÃÂ²ÃÂ½Ã‘Â)</uk>
+            <ru>ÃÂ£Ã‘ÂÃ‘â€šÃÂ°ÃÂ½ÃÂ¾ÃÂ²ÃÂ¸Ã‘â€šÃ‘Å’ ÃÂ¿ÃÂ¾ÃÂ»Ã‘Å’ÃÂ·ÃÂ¾ÃÂ²ÃÂ°Ã‘â€šÃÂµÃÂ»Ã‘Å’Ã‘ÂÃÂºÃ‘Æ’Ã‘Å½ Ã‘ÂÃ‘â€šÃÂ°ÃÂ²ÃÂºÃ‘Æ’ ÃÂ¾ÃÂ¿ÃÂ»ÃÂ°Ã‘â€šÃ‘â€¹ (0 = ÃÂ¸Ã‘ÂÃÂ¿ÃÂ¾ÃÂ»Ã‘Å’ÃÂ·ÃÂ¾ÃÂ²ÃÂ°Ã‘â€šÃ‘Å’ ÃÂ½ÃÂ°Ã‘ÂÃ‘â€šÃ‘â‚¬ÃÂ¾ÃÂ¹ÃÂºÃ‘Æ’ Ã‘Æ’Ã‘â‚¬ÃÂ¾ÃÂ²ÃÂ½Ã‘Â)</ru>
         
-            <da>Angiv brugerdefineret lÃƒÆ’Ã‚Â¸nsats (0 = brug lÃƒÆ’Ã‚Â¸nniveau-indstillingen)</da>
+            <da>Angiv brugerdefineret lÃƒÂ¸nsats (0 = brug lÃƒÂ¸nniveau-indstillingen)</da>
         </text>
         
         <text name="wc_reset">
             <en>Reset Worker Settings</en>
-            <de>Arbeitereinstellungen zurÃƒÆ’Ã‚Â¼cksetzen</de>
-            <fr>RÃƒÆ’Ã‚Â©initialiser les paramÃƒÆ’Ã‚Â¨tres des ouvriers</fr>
-            <pl>Resetuj ustawienia pracownikÃƒÆ’Ã‚Â³w</pl>
+            <de>Arbeitereinstellungen zurÃƒÂ¼cksetzen</de>
+            <fr>RÃƒÂ©initialiser les paramÃƒÂ¨tres des ouvriers</fr>
+            <pl>Resetuj ustawienia pracownikÃƒÂ³w</pl>
             <es>Restablecer config. trabajadores</es>
             <it>Ripristina impostazioni operai</it>
-            <cz>Resetovat nastavenÃƒÆ’Ã‚Â­ pracovnÃƒÆ’Ã‚Â­kÃƒâ€¦Ã‚Â¯</cz>
-            <br>Restaurar configuraÃƒÆ’Ã‚Â§ÃƒÆ’Ã‚Âµes de trabalhadores</br>
-            <uk>ÃƒÂÃ‚Â¡ÃƒÂÃ‚ÂºÃƒÂÃ‚Â¸ÃƒÂÃ‚Â½Ãƒâ€˜Ã†â€™Ãƒâ€˜Ã¢â‚¬Å¡ÃƒÂÃ‚Â¸ ÃƒÂÃ‚Â½ÃƒÂÃ‚Â°ÃƒÂÃ‚Â»ÃƒÂÃ‚Â°Ãƒâ€˜Ã‹â€ Ãƒâ€˜Ã¢â‚¬Å¡Ãƒâ€˜Ã†â€™ÃƒÂÃ‚Â²ÃƒÂÃ‚Â°ÃƒÂÃ‚Â½ÃƒÂÃ‚Â½Ãƒâ€˜Ã‚Â ÃƒÂÃ‚Â¿Ãƒâ€˜Ã¢â€šÂ¬ÃƒÂÃ‚Â°Ãƒâ€˜Ã¢â‚¬Â Ãƒâ€˜Ã¢â‚¬â€œÃƒÂÃ‚Â²ÃƒÂÃ‚Â½ÃƒÂÃ‚Â¸ÃƒÂÃ‚ÂºÃƒâ€˜Ã¢â‚¬â€œÃƒÂÃ‚Â²</uk>
-            <ru>ÃƒÂÃ‚Â¡ÃƒÂÃ‚Â±Ãƒâ€˜Ã¢â€šÂ¬ÃƒÂÃ‚Â¾Ãƒâ€˜Ã‚ÂÃƒÂÃ‚Â¸Ãƒâ€˜Ã¢â‚¬Å¡Ãƒâ€˜Ã…â€™ ÃƒÂÃ‚Â½ÃƒÂÃ‚Â°Ãƒâ€˜Ã‚ÂÃƒâ€˜Ã¢â‚¬Å¡Ãƒâ€˜Ã¢â€šÂ¬ÃƒÂÃ‚Â¾ÃƒÂÃ‚Â¹ÃƒÂÃ‚ÂºÃƒÂÃ‚Â¸ Ãƒâ€˜Ã¢â€šÂ¬ÃƒÂÃ‚Â°ÃƒÂÃ‚Â±ÃƒÂÃ‚Â¾Ãƒâ€˜Ã¢â‚¬Å¡ÃƒÂÃ‚Â½ÃƒÂÃ‚Â¸ÃƒÂÃ‚ÂºÃƒÂÃ‚Â¾ÃƒÂÃ‚Â²</ru>
+            <cz>Resetovat nastavenÃƒÂ­ pracovnÃƒÂ­kÃ…Â¯</cz>
+            <br>Restaurar configuraÃƒÂ§ÃƒÂµes de trabalhadores</br>
+            <uk>ÃÂ¡ÃÂºÃÂ¸ÃÂ½Ã‘Æ’Ã‘â€šÃÂ¸ ÃÂ½ÃÂ°ÃÂ»ÃÂ°Ã‘Ë†Ã‘â€šÃ‘Æ’ÃÂ²ÃÂ°ÃÂ½ÃÂ½Ã‘Â ÃÂ¿Ã‘â‚¬ÃÂ°Ã‘â€ Ã‘â€“ÃÂ²ÃÂ½ÃÂ¸ÃÂºÃ‘â€“ÃÂ²</uk>
+            <ru>ÃÂ¡ÃÂ±Ã‘â‚¬ÃÂ¾Ã‘ÂÃÂ¸Ã‘â€šÃ‘Å’ ÃÂ½ÃÂ°Ã‘ÂÃ‘â€šÃ‘â‚¬ÃÂ¾ÃÂ¹ÃÂºÃÂ¸ Ã‘â‚¬ÃÂ°ÃÂ±ÃÂ¾Ã‘â€šÃÂ½ÃÂ¸ÃÂºÃÂ¾ÃÂ²</ru>
         
             <da>Nulstil medarbejderindstillinger</da>
         </text>
 
-        <!-- ÃƒÂ¢Ã¢â‚¬Â¢Ã‚ÂÃƒÂ¢Ã¢â‚¬Â¢Ã‚ÂÃƒÂ¢Ã¢â‚¬Â¢Ã‚ÂÃƒÂ¢Ã¢â‚¬Â¢Ã‚Â New Pause Menu GUI strings ÃƒÂ¢Ã¢â‚¬Â¢Ã‚ÂÃƒÂ¢Ã¢â‚¬Â¢Ã‚ÂÃƒÂ¢Ã¢â‚¬Â¢Ã‚ÂÃƒÂ¢Ã¢â‚¬Â¢Ã‚Â -->
+        <!-- Ã¢â€¢ÂÃ¢â€¢ÂÃ¢â€¢ÂÃ¢â€¢Â New Pause Menu GUI strings Ã¢â€¢ÂÃ¢â€¢ÂÃ¢â€¢ÂÃ¢â€¢Â -->
 
         <text name="wc_menu_title">
             <en>Worker Costs</en>
@@ -368,7 +368,7 @@
             <br>[EN] Open Manager</br>
             <uk>[EN] Open Manager</uk>
             <ru>[EN] Open Manager</ru>
-            <da>ÃƒÆ’Ã¢â‚¬Â¦bn manager</da>
+            <da>Ãƒâ€¦bn manager</da>
         </text>
         <text name="wc_hint_open_manager">
             <en>Press Accept to open the full Worker Costs manager.</en>
@@ -382,13 +382,13 @@
             <br>[EN] Press Accept to open the full Worker Costs manager.</br>
             <uk>[EN] Press Accept to open the full Worker Costs manager.</uk>
             <ru>[EN] Press Accept to open the full Worker Costs manager.</ru>
-            <da>Tryk pÃƒÆ’Ã‚Â¥ AcceptÃƒÆ’Ã‚Â©r for at ÃƒÆ’Ã‚Â¥bne den fulde styring</da>
+            <da>Tryk pÃƒÂ¥ AcceptÃƒÂ©r for at ÃƒÂ¥bne den fulde styring</da>
         </text>
 
         <!-- Tab titles -->
         <text name="wc_tab_dashboard">
             <en>Dashboard</en>
-            <de>ÃƒÆ’Ã…â€œbersicht</de>
+            <de>ÃƒÅ“bersicht</de>
             <fr>Tableau de bord</fr>
             <pl>Panel</pl>
             <es>Panel</es>
@@ -403,16 +403,16 @@
         <text name="wc_tab_wage_settings">
             <en>Wage Settings</en>
             <de>Lohneinstellungen</de>
-            <fr>ParamÃƒÆ’Ã‚Â¨tres Salaire</fr>
-            <pl>Ustawienia pÃƒâ€¦Ã¢â‚¬Å¡ac</pl>
-            <es>ConfiguraciÃƒÆ’Ã‚Â³n salarial</es>
+            <fr>ParamÃƒÂ¨tres Salaire</fr>
+            <pl>Ustawienia pÃ…â€šac</pl>
+            <es>ConfiguraciÃƒÂ³n salarial</es>
         
             <it>[EN] Wage Settings</it>
             <cz>[EN] Wage Settings</cz>
             <br>[EN] Wage Settings</br>
             <uk>[EN] Wage Settings</uk>
             <ru>[EN] Wage Settings</ru>
-            <da>LÃƒÆ’Ã‚Â¸n indstillinger</da>
+            <da>LÃƒÂ¸n indstillinger</da>
         </text>
         
         <!-- Section headings -->
@@ -598,7 +598,7 @@
             <br>[EN] Next Payment:</br>
             <uk>[EN] Next Payment:</uk>
             <ru>[EN] Next Payment:</ru>
-            <da>NÃƒÆ’Ã‚Â¦ste lÃƒÆ’Ã‚Â¸nudbetaling:</da>
+            <da>NÃƒÂ¦ste lÃƒÂ¸nudbetaling:</da>
         </text>
         <text name="wc_label_est_cost">
             <en>Est. Cost:</en>
@@ -626,7 +626,7 @@
             <br>[EN] Farm Balance:</br>
             <uk>[EN] Farm Balance:</uk>
             <ru>[EN] Farm Balance:</ru>
-            <da>GÃƒÆ’Ã‚Â¥rdsaldo:</da>
+            <da>GÃƒÂ¥rdsaldo:</da>
         </text>
         <text name="wc_label_worker_list">
             <en>Worker Names</en>
@@ -704,7 +704,7 @@
             <en>No active workers</en>
             <de>Keine aktiven Arbeiter</de>
             <fr>Aucun ouvrier actif</fr>
-            <pl>Brak aktywnych pracownikÃƒÆ’Ã‚Â³w</pl>
+            <pl>Brak aktywnych pracownikÃƒÂ³w</pl>
             <es>Sin trabajadores activos</es>
         
             <it>[EN] No active workers</it>
@@ -720,7 +720,7 @@
             <en>Configuration</en>
             <de>Konfiguration</de>
             <fr>Configuration</fr>
-            <es>ConfiguraciÃƒÆ’Ã‚Â³n</es>
+            <es>ConfiguraciÃƒÂ³n</es>
         
             <pl>[EN] Configuration</pl>
             <it>[EN] Configuration</it>
@@ -733,7 +733,7 @@
         <text name="wc_section_summary">
             <en>Summary</en>
             <de>Zusammenfassung</de>
-            <fr>RÃƒÆ’Ã‚Â©sumÃƒÆ’Ã‚Â©</fr>
+            <fr>RÃƒÂ©sumÃƒÂ©</fr>
             <es>Resumen</es>
         
             <pl>[EN] Summary</pl>
@@ -746,8 +746,8 @@
         </text>
         <text name="wc_section_breakdown">
             <en>Labor Cost Breakdown</en>
-            <de>Arbeiter-AufschlÃƒÆ’Ã‚Â¼sselung</de>
-            <fr>DÃƒÆ’Ã‚Â©tail par ouvrier</fr>
+            <de>Arbeiter-AufschlÃƒÂ¼sselung</de>
+            <fr>DÃƒÂ©tail par ouvrier</fr>
             <es>Desglose de trabajadores</es>
 
             <pl>[EN] Labor Cost Breakdown</pl>
@@ -761,8 +761,8 @@
         <text name="wc_section_how_it_works">
             <en>How It Works</en>
             <de>Funktionsweise</de>
-            <fr>Comment ÃƒÆ’Ã‚Â§a marche</fr>
-            <es>CÃƒÆ’Ã‚Â³mo funciona</es>
+            <fr>Comment ÃƒÂ§a marche</fr>
+            <es>CÃƒÂ³mo funciona</es>
         
             <pl>[EN] How It Works</pl>
             <it>[EN] How It Works</it>
@@ -791,7 +791,7 @@
         <text name="wc_col_interval_cost">
             <en>COST / INTERVAL</en>
             <de>KOSTEN / INTERVALL</de>
-            <fr>COÃƒÆ’Ã¢â‚¬ÂºT / INTERVALLE</fr>
+            <fr>COÃƒâ€ºT / INTERVALLE</fr>
             <es>COSTO / INTERVALO</es>
         
             <pl>[EN] COST / INTERVAL</pl>
@@ -851,7 +851,7 @@
         <text name="wc_tab_about">
             <en>About</en>
             <de>Info</de>
-            <fr>ÃƒÆ’Ã¢â€šÂ¬ propos</fr>
+            <fr>Ãƒâ‚¬ propos</fr>
             <es>Acerca de</es>
         
             <pl>[EN] About</pl>
@@ -1108,7 +1108,7 @@
             <en>VERSION</en>
             <de>VERSION</de>
             <fr>VERSION</fr>
-            <es>VERSIÃƒÆ’Ã¢â‚¬Å“N</es>
+            <es>VERSIÃƒâ€œN</es>
         
             <pl>[EN] VERSION</pl>
             <it>[EN] VERSION</it>
@@ -1120,9 +1120,9 @@
         </text>
         <text name="wc_about_payment_note">
             <en>Payments follow the in-game calendar. Wages accrue while workers are active and are deducted silently once per in-game day at midnight.</en>
-            <de>Zahlungen folgen dem Spielkalender. LÃƒÆ’Ã‚Â¶hne laufen auf, wÃƒÆ’Ã‚Â¤hrend Arbeiter aktiv sind, und werden einmal pro Spieltag um Mitternacht abgezogen.</de>
-            <fr>Les paiements suivent le calendrier du jeu. Les salaires s'accumulent pendant que les ouvriers travaillent et sont dÃƒÆ’Ã‚Â©duits une fois par jour de jeu, ÃƒÆ’Ã‚Â  minuit.</fr>
-            <es>Los pagos siguen el calendario del juego. Los salarios se acumulan mientras los trabajadores estÃƒÆ’Ã‚Â¡n activos y se deducen una vez por dÃƒÆ’Ã‚Â­a de juego, a medianoche.</es>
+            <de>Zahlungen folgen dem Spielkalender. LÃƒÂ¶hne laufen auf, wÃƒÂ¤hrend Arbeiter aktiv sind, und werden einmal pro Spieltag um Mitternacht abgezogen.</de>
+            <fr>Les paiements suivent le calendrier du jeu. Les salaires s'accumulent pendant que les ouvriers travaillent et sont dÃƒÂ©duits une fois par jour de jeu, ÃƒÂ  minuit.</fr>
+            <es>Los pagos siguen el calendario del juego. Los salarios se acumulan mientras los trabajadores estÃƒÂ¡n activos y se deducen una vez por dÃƒÂ­a de juego, a medianoche.</es>
         
             <pl>[EN] Payments follow the in-game calendar. Wages accrue while workers are active and are deducted once per in-game day at midnight.</pl>
             <it>[EN] Payments follow the in-game calendar. Wages accrue while workers are active and are deducted once per in-game day at midnight.</it>
@@ -1130,7 +1130,7 @@
             <br>[EN] Payments follow the in-game calendar. Wages accrue while workers are active and are deducted once per in-game day at midnight.</br>
             <uk>[EN] Payments follow the in-game calendar. Wages accrue while workers are active and are deducted once per in-game day at midnight.</uk>
             <ru>[EN] Payments follow the in-game calendar. Wages accrue while workers are active and are deducted once per in-game day at midnight.</ru>
-            <da>Betalinger fÃƒÆ’Ã‚Â¸lger spillets kalender. LÃƒÆ’Ã‚Â¸nnen optjenes, mens medarbejderne er aktive, og trÃƒÆ’Ã‚Â¦kkes automatisk en gang pr. spildag ved midnat.</da>
+            <da>Betalinger fÃƒÂ¸lger spillets kalender. LÃƒÂ¸nnen optjenes, mens medarbejderne er aktive, og trÃƒÂ¦kkes automatisk en gang pr. spildag ved midnat.</da>
         </text>
         <text name="wc_about_body">
             <en>Realistic Worker Costs replaces the default worker pay system with a billing model based on real time.
@@ -1151,8 +1151,8 @@ The Worker Stats tab shows a live breakdown of costs per worker for the current 
 
 This mod is multiplayer compatible. Settings are saved per save game.</en>
             <de>Realistische Arbeiterkosten ersetzt das Standard-Arbeiterlohnsystem durch ein Abrechnungsmodell auf Basis von Echtzeit.</de>
-            <fr>CoÃƒÆ’Ã‚Â»ts RÃƒÆ’Ã‚Â©alistes des Ouvriers remplace le systÃƒÆ’Ã‚Â¨me de salaire par dÃƒÆ’Ã‚Â©faut par un modÃƒÆ’Ã‚Â¨le de facturation basÃƒÆ’Ã‚Â© sur le temps rÃƒÆ’Ã‚Â©el.</fr>
-            <es>Costos Realistas de Trabajadores reemplaza el sistema de pago de trabajadores predeterminado con un modelo de facturaciÃƒÆ’Ã‚Â³n basado en tiempo real.</es>
+            <fr>CoÃƒÂ»ts RÃƒÂ©alistes des Ouvriers remplace le systÃƒÂ¨me de salaire par dÃƒÂ©faut par un modÃƒÂ¨le de facturation basÃƒÂ© sur le temps rÃƒÂ©el.</fr>
+            <es>Costos Realistas de Trabajadores reemplaza el sistema de pago de trabajadores predeterminado con un modelo de facturaciÃƒÂ³n basado en tiempo real.</es>
         
             <pl>[EN] Realistic Worker Costs replaces the default worker pay system with a billing model based on real time.
 
@@ -1256,18 +1256,18 @@ WORKER STATS
 The Worker Stats tab shows a live breakdown of costs per worker for the current billing interval.
 
 This mod is multiplayer compatible. Settings are saved per save game.</ru>
-            <da>Realistic Worker Costs erstatter standardlÃƒÆ’Ã‚Â¸nssystemet for medarbejdere med en faktureringsmodel baseret pÃƒÆ’Ã‚Â¥ realtid.
+            <da>Realistic Worker Costs erstatter standardlÃƒÂ¸nssystemet for medarbejdere med en faktureringsmodel baseret pÃƒÂ¥ realtid.
 
-Medarbejdere opkrÃƒÆ’Ã‚Â¦ves efter en fast tidsplan uanset spillets hastighed. Hver aktiv AI-medarbejder koster penge ved hvert betalingsinterval.
+Medarbejdere opkrÃƒÂ¦ves efter en fast tidsplan uanset spillets hastighed. Hver aktiv AI-medarbejder koster penge ved hvert betalingsinterval.
 
 TIMEBASERET TILSTAND
-En fast sats pr. medarbejder pr. time. Omkostningerne skalerer efter, hvor mange medarbejdere der er aktive, og hvor lÃƒÆ’Ã‚Â¦nge de arbejder.
+En fast sats pr. medarbejder pr. time. Omkostningerne skalerer efter, hvor mange medarbejdere der er aktive, og hvor lÃƒÂ¦nge de arbejder.
 
 PR. HEKTAR-TILSTAND
-Medarbejdere opkrÃƒÆ’Ã‚Â¦ves baseret pÃƒÆ’Ã‚Â¥ det bearbejdede areal. Satsen pr. hektar skalerer med din indstilling for lÃƒÆ’Ã‚Â¸nniveau.
+Medarbejdere opkrÃƒÂ¦ves baseret pÃƒÂ¥ det bearbejdede areal. Satsen pr. hektar skalerer med din indstilling for lÃƒÂ¸nniveau.
 
-LÃƒÆ’Ã‹Å“NINDSTILLINGER
-Juster omkostningstilstand, lÃƒÆ’Ã‚Â¸nniveau, og slÃƒÆ’Ã‚Â¥ notifikationer til eller fra i fanen LÃƒÆ’Ã‚Â¸nindstillinger. Brug Nulstil for at gendanne standardindstillingerne.
+LÃƒËœNINDSTILLINGER
+Juster omkostningstilstand, lÃƒÂ¸nniveau, og slÃƒÂ¥ notifikationer til eller fra i fanen LÃƒÂ¸nindstillinger. Brug Nulstil for at gendanne standardindstillingerne.
 
 MEDARBEJDERSTATISTIK
 Fanen Medarbejderstatistik viser en live oversigt over omkostninger pr. medarbejder for det aktuelle betalingsinterval.
@@ -1278,9 +1278,9 @@ Denne mod er kompatibel med multiplayer. Indstillinger gemmes pr. savegame.</da>
         <!-- WCMenuPage landing -->
         <text name="wc_menu_description">
             <en>Monitor your worker costs and billing status at a glance. Open the Worker Manager for live stats, detailed breakdowns, and full settings control.</en>
-            <de>ÃƒÆ’Ã…â€œberwachen Sie Ihre Arbeitskosten und den Abrechnungsstatus auf einen Blick.</de>
-            <fr>Surveillez vos coÃƒÆ’Ã‚Â»ts de main-d'oeuvre d'un coup d'oeil. Ouvrez le Gestionnaire pour les statistiques en direct.</fr>
-            <es>Supervise los costos de sus trabajadores de un vistazo. Abra el Administrador para estadÃƒÆ’Ã‚Â­sticas en vivo.</es>
+            <de>ÃƒÅ“berwachen Sie Ihre Arbeitskosten und den Abrechnungsstatus auf einen Blick.</de>
+            <fr>Surveillez vos coÃƒÂ»ts de main-d'oeuvre d'un coup d'oeil. Ouvrez le Gestionnaire pour les statistiques en direct.</fr>
+            <es>Supervise los costos de sus trabajadores de un vistazo. Abra el Administrador para estadÃƒÂ­sticas en vivo.</es>
         
             <pl>[EN] Monitor your worker costs and billing status at a glance. Open the Worker Manager for live stats, detailed breakdowns, and full settings control.</pl>
             <it>[EN] Monitor your worker costs and billing status at a glance. Open the Worker Manager for live stats, detailed breakdowns, and full settings control.</it>
@@ -1288,7 +1288,7 @@ Denne mod er kompatibel med multiplayer. Indstillinger gemmes pr. savegame.</da>
             <br>[EN] Monitor your worker costs and billing status at a glance. Open the Worker Manager for live stats, detailed breakdowns, and full settings control.</br>
             <uk>[EN] Monitor your worker costs and billing status at a glance. Open the Worker Manager for live stats, detailed breakdowns, and full settings control.</uk>
             <ru>[EN] Monitor your worker costs and billing status at a glance. Open the Worker Manager for live stats, detailed breakdowns, and full settings control.</ru>
-            <da>FÃƒÆ’Ã‚Â¥ et hurtigt overblik over dine medarbejderomkostninger og betalingsstatus. ÃƒÆ’Ã¢â‚¬Â¦bn medarbejderstyringen for live statistik, detaljerede oversigter og fuld kontrol over indstillingerne</da>
+            <da>FÃƒÂ¥ et hurtigt overblik over dine medarbejderomkostninger og betalingsstatus. Ãƒâ€¦bn medarbejderstyringen for live statistik, detaljerede oversigter og fuld kontrol over indstillingerne</da>
         </text>
 
         <!-- Help text for Wage Settings tab -->
@@ -1440,17 +1440,17 @@ Settled once per in-game day at midnight, based on the in-game time worked.
 Use Reset to restore all settings to their defaults.</ru>
             <da>BETALINGSSTRATEGI
 Timebaseret - betal en fast sats pr. medarbejder pr. arbejdstime.
-Pr. hektar - betal baseret pÃƒÆ’Ã‚Â¥ det bearbejdede areal.
+Pr. hektar - betal baseret pÃƒÂ¥ det bearbejdede areal.
 
 KOMPENSATIONSNIVEAU
 Lav = $15 pr. medarbejder pr. time
 Mellem = $25 pr. medarbejder pr. time
-HÃƒÆ’Ã‚Â¸j = $40 pr. medarbejder pr. time
+HÃƒÂ¸j = $40 pr. medarbejder pr. time
 
 BETALINGER
-Afregnes en gang pr. spildag ved midnat, baseret pÃƒÆ’Ã‚Â¥ den arbejdede tid i spillet.
+Afregnes en gang pr. spildag ved midnat, baseret pÃƒÂ¥ den arbejdede tid i spillet.
 
-Brug Nulstil for at gendanne alle indstillinger til standardvÃƒÆ’Ã‚Â¦rdierne.</da>
+Brug Nulstil for at gendanne alle indstillinger til standardvÃƒÂ¦rdierne.</da>
         </text>
         <text name="wc_help_body_ha">
             <en>PAYMENT STRATEGY
@@ -1575,17 +1575,17 @@ Settled once per in-game day at midnight, based on area worked. Workers not curr
 
 Use Reset to restore all settings to their defaults.</ru>
             <da>BETALINGSSTRATEGI
-Pr. hektar - medarbejdere opkrÃƒÆ’Ã‚Â¦ves pr. hektar bearbejdet mark siden sidste afregning.
+Pr. hektar - medarbejdere opkrÃƒÂ¦ves pr. hektar bearbejdet mark siden sidste afregning.
 
 KOMPENSATIONSNIVEAU (pr. hektar)
 Lav = $15 pr. hektar bearbejdet
 Mellem = $25 pr. hektar bearbejdet
-HÃƒÆ’Ã‚Â¸j = $40 pr. hektar bearbejdet
+HÃƒÂ¸j = $40 pr. hektar bearbejdet
 
 BETALINGER
-Afregnes en gang pr. spildag ved midnat, baseret pÃƒÆ’Ã‚Â¥ det bearbejdede areal. Medarbejdere, der ikke er aktive, opkrÃƒÆ’Ã‚Â¦ves ikke for den pÃƒÆ’Ã‚Â¥gÃƒÆ’Ã‚Â¦ldende dag.
+Afregnes en gang pr. spildag ved midnat, baseret pÃƒÂ¥ det bearbejdede areal. Medarbejdere, der ikke er aktive, opkrÃƒÂ¦ves ikke for den pÃƒÂ¥gÃƒÂ¦ldende dag.
 
-Brug Nulstil for at gendanne alle indstillinger til standardvÃƒÆ’Ã‚Â¦rdierne.</da>
+Brug Nulstil for at gendanne alle indstillinger til standardvÃƒÂ¦rdierne.</da>
         </text>
         <text name="rf_pda_col_area">
             <br>[EN] Area</br>
@@ -1693,59 +1693,59 @@ Brug Nulstil for at gendanne alle indstillinger til standardvÃƒÆ’Ã‚Â¦r
         </text>
                 <text name="wc_rf_pda_open_manager">
             <br>Abrir gerenciador de trabalhadores</br>
-            <cz>OtevÅ™Ã­t sprÃ¡vce pracovnÃ­kÅ¯</cz>
-            <da>Ã…bn medarbejderstyring</da>
-            <de>Arbeitermanager Ã¶ffnen</de>
+            <cz>Otevřít správce pracovníků</cz>
+            <da>Åbn medarbejderstyring</da>
+            <de>Arbeitermanager öffnen</de>
             <en>Open Worker Manager</en>
             <es>Abrir gestor de trabajadores</es>
             <fr>Ouvrir le gestionnaire d'ouvriers</fr>
             <it>Apri gestore operai</it>
-            <pl>OtwÃ³rz menedÅ¼era pracownikÃ³w</pl>
-            <ru>ÐžÑ‚ÐºÑ€Ñ‹Ñ‚ÑŒ Ð¼ÐµÐ½ÐµÐ´Ð¶ÐµÑ€ Ñ€Ð°Ð±Ð¾Ñ‚Ð½Ð¸ÐºÐ¾Ð²</ru>
-            <uk>Ð’Ñ–Ð´ÐºÑ€Ð¸Ñ‚Ð¸ Ð¼ÐµÐ½ÐµÐ´Ð¶ÐµÑ€ Ð¿Ñ€Ð°Ñ†Ñ–Ð²Ð½Ð¸ÐºÑ–Ð²</uk>
+            <pl>Otwórz menedżera pracowników</pl>
+            <ru>Открыть менеджер работников</ru>
+            <uk>Відкрити менеджер працівників</uk>
             <nl>Werkersbeheer openen</nl>
             <pt>Abrir gestor de trabalhadores</pt>
-            <sv>Ã–ppna arbetshanteraren</sv>
-            <no>Ã…pne arbeiderbehandler</no>
-            <fi>Avaa tyÃ¶ntekijÃ¤hallinta</fi>
-            <hu>DolgozÃ³kezelÅ‘ megnyitÃ¡sa</hu>
+            <sv>Öppna arbetshanteraren</sv>
+            <no>Åpne arbeiderbehandler</no>
+            <fi>Avaa työntekijähallinta</fi>
+            <hu>Dolgozókezelő megnyitása</hu>
             <ro>Deschide managerul de muncitori</ro>
-            <tr>Ä°ÅŸÃ§i yÃ¶neticisini aÃ§</tr>
-            <jp>ä½œæ¥­å“¡ãƒžãƒãƒ¼ã‚¸ãƒ£ãƒ¼ã‚’é–‹ã</jp>
-            <kr>ìž‘ì—…ìž ê´€ë¦¬ìž ì—´ê¸°</kr>
-            <ct>é–‹å•Ÿå·¥äººç®¡ç†å“¡</ct>
+            <tr>İşçi yöneticisini aç</tr>
+            <jp>作業員マネージャーを開く</jp>
+            <kr>작업자 관리자 열기</kr>
+            <ct>開啟工人管理員</ct>
             <fc>Ouvrir le gestionnaire d'ouvriers</fc>
             <ea>Abrir gestor de trabajadores</ea>
             <id>Buka manajer pekerja</id>
-            <vi>Má»Ÿ trÃ¬nh quáº£n lÃ½ cÃ´ng nhÃ¢n</vi>
+            <vi>Mở trình quản lý công nhân</vi>
         </text>
         <text name="sf_pda_btn_rotation_planner">
-            <br>Planejador de rotaÃ§Ã£o</br>
-            <cz>PlÃ¡novaÄ osevnÃ­ho postupu</cz>
-            <da>RotationsplanlÃ¦gger</da>
+            <br>Planejador de rotação</br>
+            <cz>Plánovač osevního postupu</cz>
+            <da>Rotationsplanlægger</da>
             <de>Fruchtfolgeplaner</de>
             <en>Rotation Planner</en>
-            <es>Planificador de rotaciÃ³n</es>
+            <es>Planificador de rotación</es>
             <fr>Planificateur de rotation</fr>
             <it>Pianificatore rotazioni</it>
-            <pl>Planer pÅ‚odozmianu</pl>
-            <ru>ÐŸÐ»Ð°Ð½Ð¸Ñ€Ð¾Ð²Ñ‰Ð¸Ðº ÑÐµÐ²Ð¾Ð¾Ð±Ð¾Ñ€Ð¾Ñ‚Ð°</ru>
-            <uk>ÐŸÐ»Ð°Ð½ÑƒÐ²Ð°Ð»ÑŒÐ½Ð¸Ðº ÑÑ–Ð²Ð¾Ð·Ð¼Ñ–Ð½Ð¸</uk>
+            <pl>Planer płodozmianu</pl>
+            <ru>Планировщик севооборота</ru>
+            <uk>Планувальник сівозміни</uk>
             <nl>Rotatieplanner</nl>
-            <pt>Planeador de rotaÃ§Ã£o</pt>
-            <sv>VÃ¤xtfÃ¶ljdsplanerare</sv>
+            <pt>Planeador de rotação</pt>
+            <sv>Växtföljdsplanerare</sv>
             <no>Rotasjonsplanlegger</no>
             <fi>Viljelykiertosuunnittelija</fi>
-            <hu>VetÃ©sforgÃ³-tervezÅ‘</hu>
-            <ro>Planificator de rotaÈ›ie</ro>
-            <tr>Ekim nÃ¶beti planlayÄ±cÄ±</tr>
-            <jp>è¼ªä½œãƒ—ãƒ©ãƒ³ãƒŠãƒ¼</jp>
-            <kr>ìœ¤ìž‘ ê³„íšê¸°</kr>
-            <ct>è¼ªä½œè¦åŠƒ</ct>
+            <hu>Vetésforgó-tervező</hu>
+            <ro>Planificator de rotație</ro>
+            <tr>Ekim nöbeti planlayıcı</tr>
+            <jp>輪作プランナー</jp>
+            <kr>윤작 계획기</kr>
+            <ct>輪作規劃</ct>
             <fc>Planificateur de rotation</fc>
-            <ea>Planificador de rotaciÃ³n</ea>
+            <ea>Planificador de rotación</ea>
             <id>Perencana rotasi</id>
-            <vi>Láº­p káº¿ hoáº¡ch luÃ¢n canh</vi>
+            <vi>Lập kế hoạch luân canh</vi>
         </text>
         <text name="sf_pda_btn_field_detail">
             <br>Detalhe do campo</br>
@@ -1754,26 +1754,26 @@ Brug Nulstil for at gendanne alle indstillinger til standardvÃƒÆ’Ã‚Â¦r
             <de>Felddetails</de>
             <en>Field Detail</en>
             <es>Detalle del campo</es>
-            <fr>DÃ©tail du champ</fr>
+            <fr>Détail du champ</fr>
             <it>Dettaglio campo</it>
-            <pl>SzczegÃ³Å‚y pola</pl>
-            <ru>Ð¡Ð²ÐµÐ´ÐµÐ½Ð¸Ñ Ð¾ Ð¿Ð¾Ð»Ðµ</ru>
-            <uk>Ð”ÐµÑ‚Ð°Ð»Ñ– Ð¿Ð¾Ð»Ñ</uk>
+            <pl>Szczegóły pola</pl>
+            <ru>Сведения о поле</ru>
+            <uk>Деталі поля</uk>
             <nl>Veldgegevens</nl>
             <pt>Detalhe do campo</pt>
-            <sv>FÃ¤ltdetaljer</sv>
+            <sv>Fältdetaljer</sv>
             <no>Feltdetaljer</no>
             <fi>Pellon tiedot</fi>
-            <hu>TÃ¡blarÃ©szletek</hu>
-            <ro>Detaliu cÃ¢mp</ro>
-            <tr>Tarla detayÄ±</tr>
-            <jp>ç•‘ã®è©³ç´°</jp>
-            <kr>ë°¯ ìƒì„¸</kr>
-            <ct>ç”°åœ°è©³æƒ…</ct>
-            <fc>DÃ©tail du champ</fc>
+            <hu>Táblarészletek</hu>
+            <ro>Detaliu câmp</ro>
+            <tr>Tarla detayı</tr>
+            <jp>畑の詳細</jp>
+            <kr>밯 상세</kr>
+            <ct>田地詳情</ct>
+            <fc>Détail du champ</fc>
             <ea>Detalle del campo</ea>
             <id>Detail lahan</id>
-            <vi>Chi tiáº¿t thá»­a ruá»™ng</vi>
+            <vi>Chi tiết thửa ruộng</vi>
         </text>
 </l10n>
 

--- a/modDesc.xml
+++ b/modDesc.xml
@@ -1,31 +1,31 @@
 <?xml version="1.0" encoding="utf-8" standalone="no" ?>
 <modDesc descVersion="92">
     <author>TisonK</author>
-    <version>2.2.3.43</version>
+    <version>2.2.3.44</version>
     <modName>FS25_WorkerCostsMod</modName>
     <title>
         <en>Realistic Worker Costs</en>
         <de>Realistische Arbeiterkosten</de>
-        <fr>CoÃƒÂ»ts RÃƒÂ©alistes des Ouvriers</fr>
-        <pl>Realistyczne Koszty PracownikÃƒÂ³w</pl>
+        <fr>CoÃƒÆ’Ã‚Â»ts RÃƒÆ’Ã‚Â©alistes des Ouvriers</fr>
+        <pl>Realistyczne Koszty PracownikÃƒÆ’Ã‚Â³w</pl>
         <es>Costos Realistas de Trabajadores</es>
         <it>Costi Realistici Operai</it>
-        <cz>RealistickÃƒÂ© NÃƒÂ¡klady na PracovnÃƒÂ­ky</cz>
+        <cz>RealistickÃƒÆ’Ã‚Â© NÃƒÆ’Ã‚Â¡klady na PracovnÃƒÆ’Ã‚Â­ky</cz>
         <br>Custos Realistas de Trabalhadores</br>
-        <uk>ÃÂ ÃÂµÃÂ°ÃÂ»Ã‘â€“Ã‘ÂÃ‘â€šÃÂ¸Ã‘â€¡ÃÂ½Ã‘â€“ ÃÂ²ÃÂ¸Ã‘â€šÃ‘â‚¬ÃÂ°Ã‘â€šÃÂ¸ ÃÂ½ÃÂ° ÃÂ¿Ã‘â‚¬ÃÂ°Ã‘â€ Ã‘â€“ÃÂ²ÃÂ½ÃÂ¸ÃÂºÃ‘â€“ÃÂ²</uk>
-        <ru>ÃÂ ÃÂµÃÂ°ÃÂ»ÃÂ¸Ã‘ÂÃ‘â€šÃÂ¸Ã‘â€¡ÃÂ½Ã‘â€¹ÃÂµ Ã‘â‚¬ÃÂ°Ã‘ÂÃ‘â€¦ÃÂ¾ÃÂ´Ã‘â€¹ ÃÂ½ÃÂ° Ã‘â‚¬ÃÂ°ÃÂ±ÃÂ¾Ã‘â€šÃÂ½ÃÂ¸ÃÂºÃÂ¾ÃÂ²</ru>
+        <uk>ÃƒÂÃ‚Â ÃƒÂÃ‚ÂµÃƒÂÃ‚Â°ÃƒÂÃ‚Â»Ãƒâ€˜Ã¢â‚¬â€œÃƒâ€˜Ã‚ÂÃƒâ€˜Ã¢â‚¬Å¡ÃƒÂÃ‚Â¸Ãƒâ€˜Ã¢â‚¬Â¡ÃƒÂÃ‚Â½Ãƒâ€˜Ã¢â‚¬â€œ ÃƒÂÃ‚Â²ÃƒÂÃ‚Â¸Ãƒâ€˜Ã¢â‚¬Å¡Ãƒâ€˜Ã¢â€šÂ¬ÃƒÂÃ‚Â°Ãƒâ€˜Ã¢â‚¬Å¡ÃƒÂÃ‚Â¸ ÃƒÂÃ‚Â½ÃƒÂÃ‚Â° ÃƒÂÃ‚Â¿Ãƒâ€˜Ã¢â€šÂ¬ÃƒÂÃ‚Â°Ãƒâ€˜Ã¢â‚¬Â Ãƒâ€˜Ã¢â‚¬â€œÃƒÂÃ‚Â²ÃƒÂÃ‚Â½ÃƒÂÃ‚Â¸ÃƒÂÃ‚ÂºÃƒâ€˜Ã¢â‚¬â€œÃƒÂÃ‚Â²</uk>
+        <ru>ÃƒÂÃ‚Â ÃƒÂÃ‚ÂµÃƒÂÃ‚Â°ÃƒÂÃ‚Â»ÃƒÂÃ‚Â¸Ãƒâ€˜Ã‚ÂÃƒâ€˜Ã¢â‚¬Å¡ÃƒÂÃ‚Â¸Ãƒâ€˜Ã¢â‚¬Â¡ÃƒÂÃ‚Â½Ãƒâ€˜Ã¢â‚¬Â¹ÃƒÂÃ‚Âµ Ãƒâ€˜Ã¢â€šÂ¬ÃƒÂÃ‚Â°Ãƒâ€˜Ã‚ÂÃƒâ€˜Ã¢â‚¬Â¦ÃƒÂÃ‚Â¾ÃƒÂÃ‚Â´Ãƒâ€˜Ã¢â‚¬Â¹ ÃƒÂÃ‚Â½ÃƒÂÃ‚Â° Ãƒâ€˜Ã¢â€šÂ¬ÃƒÂÃ‚Â°ÃƒÂÃ‚Â±ÃƒÂÃ‚Â¾Ãƒâ€˜Ã¢â‚¬Å¡ÃƒÂÃ‚Â½ÃƒÂÃ‚Â¸ÃƒÂÃ‚ÂºÃƒÂÃ‚Â¾ÃƒÂÃ‚Â²</ru>
     </title>
     <description>
         <en>Adds hourly wages for workers with skill-based pricing and configurable rates.</en>
-        <de>FÃƒÂ¼gt stÃƒÂ¼ndliche LÃƒÂ¶hne fÃƒÂ¼r Arbeiter mit fÃƒÂ¤higkeitsbasierten Preisen und konfigurierbaren SÃƒÂ¤tzen hinzu.</de>
-        <fr>Ajoute des salaires horaires pour les ouvriers avec tarification basÃƒÂ©e sur les compÃƒÂ©tences et taux configurables.</fr>
-        <pl>Dodaje godzinowe stawki dla pracownikÃƒÂ³w z cenami opartymi na umiejÃ„â„¢tnoÃ…â€ºciach i konfigurowalnymi stawkami.</pl>
-        <es>AÃƒÂ±ade salarios por hora para trabajadores con precios basados en habilidades y tarifas configurables.</es>
-        <it>Aggiunge salari orari per operai con prezzi basati su abilitÃƒÂ  e tariffe configurabili.</it>
-        <cz>PÃ…â„¢idÃƒÂ¡vÃƒÂ¡ hodinovÃƒÂ© mzdy pro pracovnÃƒÂ­ky s cenami zaloÃ…Â¾enÃƒÂ½mi na dovednostech a konfigurovatelnÃƒÂ½mi sazbami.</cz>
-        <br>Adiciona salÃƒÂ¡rios por hora para trabalhadores com preÃƒÂ§os baseados em habilidades e taxas configurÃƒÂ¡veis.</br>
-        <uk>Ãâ€ÃÂ¾ÃÂ´ÃÂ°Ã‘â€ ÃÂ¿ÃÂ¾ÃÂ³ÃÂ¾ÃÂ´ÃÂ¸ÃÂ½ÃÂ½Ã‘Æ’ ÃÂ¾ÃÂ¿ÃÂ»ÃÂ°Ã‘â€šÃ‘Æ’ ÃÂ¿Ã‘â‚¬ÃÂ°Ã‘â€ Ã‘â€“ÃÂ²ÃÂ½ÃÂ¸ÃÂºÃÂ°ÃÂ¼ ÃÂ· Ã‘â€ Ã‘â€“ÃÂ½ÃÂ¾Ã‘Å½ ÃÂ½ÃÂ° ÃÂ¾Ã‘ÂÃÂ½ÃÂ¾ÃÂ²Ã‘â€“ ÃÂ½ÃÂ°ÃÂ²ÃÂ¸Ã‘â€¡ÃÂ¾ÃÂº Ã‘â€šÃÂ° ÃÂ½ÃÂ°Ã‘ÂÃ‘â€šÃ‘â‚¬ÃÂ¾Ã‘Å½ÃÂ²ÃÂ°ÃÂ½ÃÂ¸ÃÂ¼ÃÂ¸ Ã‘ÂÃ‘â€šÃÂ°ÃÂ²ÃÂºÃÂ°ÃÂ¼ÃÂ¸.</uk>
-        <ru>Ãâ€ÃÂ¾ÃÂ±ÃÂ°ÃÂ²ÃÂ»Ã‘ÂÃÂµÃ‘â€š ÃÂ¿ÃÂ¾Ã‘â€¡ÃÂ°Ã‘ÂÃÂ¾ÃÂ²Ã‘Æ’Ã‘Å½ ÃÂ¾ÃÂ¿ÃÂ»ÃÂ°Ã‘â€šÃ‘Æ’ Ã‘â‚¬ÃÂ°ÃÂ±ÃÂ¾Ã‘â€šÃÂ½ÃÂ¸ÃÂºÃÂ°ÃÂ¼ Ã‘Â Ã‘â€ ÃÂµÃÂ½ÃÂ°ÃÂ¼ÃÂ¸ ÃÂ½ÃÂ° ÃÂ¾Ã‘ÂÃÂ½ÃÂ¾ÃÂ²ÃÂµ ÃÂ½ÃÂ°ÃÂ²Ã‘â€¹ÃÂºÃÂ¾ÃÂ² ÃÂ¸ ÃÂ½ÃÂ°Ã‘ÂÃ‘â€šÃ‘â‚¬ÃÂ°ÃÂ¸ÃÂ²ÃÂ°ÃÂµÃÂ¼Ã‘â€¹ÃÂ¼ÃÂ¸ Ã‘ÂÃ‘â€šÃÂ°ÃÂ²ÃÂºÃÂ°ÃÂ¼ÃÂ¸.</ru>
+        <de>FÃƒÆ’Ã‚Â¼gt stÃƒÆ’Ã‚Â¼ndliche LÃƒÆ’Ã‚Â¶hne fÃƒÆ’Ã‚Â¼r Arbeiter mit fÃƒÆ’Ã‚Â¤higkeitsbasierten Preisen und konfigurierbaren SÃƒÆ’Ã‚Â¤tzen hinzu.</de>
+        <fr>Ajoute des salaires horaires pour les ouvriers avec tarification basÃƒÆ’Ã‚Â©e sur les compÃƒÆ’Ã‚Â©tences et taux configurables.</fr>
+        <pl>Dodaje godzinowe stawki dla pracownikÃƒÆ’Ã‚Â³w z cenami opartymi na umiejÃƒâ€žÃ¢â€žÂ¢tnoÃƒâ€¦Ã¢â‚¬Âºciach i konfigurowalnymi stawkami.</pl>
+        <es>AÃƒÆ’Ã‚Â±ade salarios por hora para trabajadores con precios basados en habilidades y tarifas configurables.</es>
+        <it>Aggiunge salari orari per operai con prezzi basati su abilitÃƒÆ’Ã‚Â  e tariffe configurabili.</it>
+        <cz>PÃƒâ€¦Ã¢â€žÂ¢idÃƒÆ’Ã‚Â¡vÃƒÆ’Ã‚Â¡ hodinovÃƒÆ’Ã‚Â© mzdy pro pracovnÃƒÆ’Ã‚Â­ky s cenami zaloÃƒâ€¦Ã‚Â¾enÃƒÆ’Ã‚Â½mi na dovednostech a konfigurovatelnÃƒÆ’Ã‚Â½mi sazbami.</cz>
+        <br>Adiciona salÃƒÆ’Ã‚Â¡rios por hora para trabalhadores com preÃƒÆ’Ã‚Â§os baseados em habilidades e taxas configurÃƒÆ’Ã‚Â¡veis.</br>
+        <uk>ÃƒÂÃ¢â‚¬ÂÃƒÂÃ‚Â¾ÃƒÂÃ‚Â´ÃƒÂÃ‚Â°Ãƒâ€˜Ã¢â‚¬Â ÃƒÂÃ‚Â¿ÃƒÂÃ‚Â¾ÃƒÂÃ‚Â³ÃƒÂÃ‚Â¾ÃƒÂÃ‚Â´ÃƒÂÃ‚Â¸ÃƒÂÃ‚Â½ÃƒÂÃ‚Â½Ãƒâ€˜Ã†â€™ ÃƒÂÃ‚Â¾ÃƒÂÃ‚Â¿ÃƒÂÃ‚Â»ÃƒÂÃ‚Â°Ãƒâ€˜Ã¢â‚¬Å¡Ãƒâ€˜Ã†â€™ ÃƒÂÃ‚Â¿Ãƒâ€˜Ã¢â€šÂ¬ÃƒÂÃ‚Â°Ãƒâ€˜Ã¢â‚¬Â Ãƒâ€˜Ã¢â‚¬â€œÃƒÂÃ‚Â²ÃƒÂÃ‚Â½ÃƒÂÃ‚Â¸ÃƒÂÃ‚ÂºÃƒÂÃ‚Â°ÃƒÂÃ‚Â¼ ÃƒÂÃ‚Â· Ãƒâ€˜Ã¢â‚¬Â Ãƒâ€˜Ã¢â‚¬â€œÃƒÂÃ‚Â½ÃƒÂÃ‚Â¾Ãƒâ€˜Ã…Â½ ÃƒÂÃ‚Â½ÃƒÂÃ‚Â° ÃƒÂÃ‚Â¾Ãƒâ€˜Ã‚ÂÃƒÂÃ‚Â½ÃƒÂÃ‚Â¾ÃƒÂÃ‚Â²Ãƒâ€˜Ã¢â‚¬â€œ ÃƒÂÃ‚Â½ÃƒÂÃ‚Â°ÃƒÂÃ‚Â²ÃƒÂÃ‚Â¸Ãƒâ€˜Ã¢â‚¬Â¡ÃƒÂÃ‚Â¾ÃƒÂÃ‚Âº Ãƒâ€˜Ã¢â‚¬Å¡ÃƒÂÃ‚Â° ÃƒÂÃ‚Â½ÃƒÂÃ‚Â°Ãƒâ€˜Ã‚ÂÃƒâ€˜Ã¢â‚¬Å¡Ãƒâ€˜Ã¢â€šÂ¬ÃƒÂÃ‚Â¾Ãƒâ€˜Ã…Â½ÃƒÂÃ‚Â²ÃƒÂÃ‚Â°ÃƒÂÃ‚Â½ÃƒÂÃ‚Â¸ÃƒÂÃ‚Â¼ÃƒÂÃ‚Â¸ Ãƒâ€˜Ã‚ÂÃƒâ€˜Ã¢â‚¬Å¡ÃƒÂÃ‚Â°ÃƒÂÃ‚Â²ÃƒÂÃ‚ÂºÃƒÂÃ‚Â°ÃƒÂÃ‚Â¼ÃƒÂÃ‚Â¸.</uk>
+        <ru>ÃƒÂÃ¢â‚¬ÂÃƒÂÃ‚Â¾ÃƒÂÃ‚Â±ÃƒÂÃ‚Â°ÃƒÂÃ‚Â²ÃƒÂÃ‚Â»Ãƒâ€˜Ã‚ÂÃƒÂÃ‚ÂµÃƒâ€˜Ã¢â‚¬Å¡ ÃƒÂÃ‚Â¿ÃƒÂÃ‚Â¾Ãƒâ€˜Ã¢â‚¬Â¡ÃƒÂÃ‚Â°Ãƒâ€˜Ã‚ÂÃƒÂÃ‚Â¾ÃƒÂÃ‚Â²Ãƒâ€˜Ã†â€™Ãƒâ€˜Ã…Â½ ÃƒÂÃ‚Â¾ÃƒÂÃ‚Â¿ÃƒÂÃ‚Â»ÃƒÂÃ‚Â°Ãƒâ€˜Ã¢â‚¬Å¡Ãƒâ€˜Ã†â€™ Ãƒâ€˜Ã¢â€šÂ¬ÃƒÂÃ‚Â°ÃƒÂÃ‚Â±ÃƒÂÃ‚Â¾Ãƒâ€˜Ã¢â‚¬Å¡ÃƒÂÃ‚Â½ÃƒÂÃ‚Â¸ÃƒÂÃ‚ÂºÃƒÂÃ‚Â°ÃƒÂÃ‚Â¼ Ãƒâ€˜Ã‚Â Ãƒâ€˜Ã¢â‚¬Â ÃƒÂÃ‚ÂµÃƒÂÃ‚Â½ÃƒÂÃ‚Â°ÃƒÂÃ‚Â¼ÃƒÂÃ‚Â¸ ÃƒÂÃ‚Â½ÃƒÂÃ‚Â° ÃƒÂÃ‚Â¾Ãƒâ€˜Ã‚ÂÃƒÂÃ‚Â½ÃƒÂÃ‚Â¾ÃƒÂÃ‚Â²ÃƒÂÃ‚Âµ ÃƒÂÃ‚Â½ÃƒÂÃ‚Â°ÃƒÂÃ‚Â²Ãƒâ€˜Ã¢â‚¬Â¹ÃƒÂÃ‚ÂºÃƒÂÃ‚Â¾ÃƒÂÃ‚Â² ÃƒÂÃ‚Â¸ ÃƒÂÃ‚Â½ÃƒÂÃ‚Â°Ãƒâ€˜Ã‚ÂÃƒâ€˜Ã¢â‚¬Å¡Ãƒâ€˜Ã¢â€šÂ¬ÃƒÂÃ‚Â°ÃƒÂÃ‚Â¸ÃƒÂÃ‚Â²ÃƒÂÃ‚Â°ÃƒÂÃ‚ÂµÃƒÂÃ‚Â¼Ãƒâ€˜Ã¢â‚¬Â¹ÃƒÂÃ‚Â¼ÃƒÂÃ‚Â¸ Ãƒâ€˜Ã‚ÂÃƒâ€˜Ã¢â‚¬Å¡ÃƒÂÃ‚Â°ÃƒÂÃ‚Â²ÃƒÂÃ‚ÂºÃƒÂÃ‚Â°ÃƒÂÃ‚Â¼ÃƒÂÃ‚Â¸.</ru>
     </description>
     <iconFilename>icon.dds</iconFilename>
     
@@ -43,43 +43,43 @@
         <text name="wc_section">
             <en>Worker Costs Mod</en>
             <de>Arbeiterkosten-Mod</de>
-            <fr>Module CoÃƒÂ»ts Ouvriers</fr>
-            <pl>Mod KosztÃƒÂ³w PracownikÃƒÂ³w</pl>
+            <fr>Module CoÃƒÆ’Ã‚Â»ts Ouvriers</fr>
+            <pl>Mod KosztÃƒÆ’Ã‚Â³w PracownikÃƒÆ’Ã‚Â³w</pl>
             <es>Mod Costos Trabajadores</es>
             <it>Mod Costi Operai</it>
-            <cz>Mod NÃƒÂ¡kladÃ…Â¯ na PracovnÃƒÂ­ky</cz>
+            <cz>Mod NÃƒÆ’Ã‚Â¡kladÃƒâ€¦Ã‚Â¯ na PracovnÃƒÆ’Ã‚Â­ky</cz>
             <br>Mod Custos Trabalhadores</br>
-            <uk>ÃÅ“ÃÂ¾ÃÂ´ ÃÂ²ÃÂ¸Ã‘â€šÃ‘â‚¬ÃÂ°Ã‘â€š ÃÂ½ÃÂ° ÃÂ¿Ã‘â‚¬ÃÂ°Ã‘â€ Ã‘â€“ÃÂ²ÃÂ½ÃÂ¸ÃÂºÃ‘â€“ÃÂ²</uk>
-            <ru>ÃÅ“ÃÂ¾ÃÂ´ Ã‘â‚¬ÃÂ°Ã‘ÂÃ‘â€¦ÃÂ¾ÃÂ´ÃÂ¾ÃÂ² ÃÂ½ÃÂ° Ã‘â‚¬ÃÂ°ÃÂ±ÃÂ¾Ã‘â€šÃÂ½ÃÂ¸ÃÂºÃÂ¾ÃÂ²</ru>
+            <uk>ÃƒÂÃ…â€œÃƒÂÃ‚Â¾ÃƒÂÃ‚Â´ ÃƒÂÃ‚Â²ÃƒÂÃ‚Â¸Ãƒâ€˜Ã¢â‚¬Å¡Ãƒâ€˜Ã¢â€šÂ¬ÃƒÂÃ‚Â°Ãƒâ€˜Ã¢â‚¬Å¡ ÃƒÂÃ‚Â½ÃƒÂÃ‚Â° ÃƒÂÃ‚Â¿Ãƒâ€˜Ã¢â€šÂ¬ÃƒÂÃ‚Â°Ãƒâ€˜Ã¢â‚¬Â Ãƒâ€˜Ã¢â‚¬â€œÃƒÂÃ‚Â²ÃƒÂÃ‚Â½ÃƒÂÃ‚Â¸ÃƒÂÃ‚ÂºÃƒâ€˜Ã¢â‚¬â€œÃƒÂÃ‚Â²</uk>
+            <ru>ÃƒÂÃ…â€œÃƒÂÃ‚Â¾ÃƒÂÃ‚Â´ Ãƒâ€˜Ã¢â€šÂ¬ÃƒÂÃ‚Â°Ãƒâ€˜Ã‚ÂÃƒâ€˜Ã¢â‚¬Â¦ÃƒÂÃ‚Â¾ÃƒÂÃ‚Â´ÃƒÂÃ‚Â¾ÃƒÂÃ‚Â² ÃƒÂÃ‚Â½ÃƒÂÃ‚Â° Ãƒâ€˜Ã¢â€šÂ¬ÃƒÂÃ‚Â°ÃƒÂÃ‚Â±ÃƒÂÃ‚Â¾Ãƒâ€˜Ã¢â‚¬Å¡ÃƒÂÃ‚Â½ÃƒÂÃ‚Â¸ÃƒÂÃ‚ÂºÃƒÂÃ‚Â¾ÃƒÂÃ‚Â²</ru>
         
             <da>Mod til medarbejderomkostninger</da>
         </text>
 
         <text name="input_WC_OPEN_ROSTER">
             <en>Open Worker Roster</en>
-            <de>Arbeiterliste ÃƒÂ¶ffnen</de>
+            <de>Arbeiterliste ÃƒÆ’Ã‚Â¶ffnen</de>
             <fr>Ouvrir la liste des ouvriers</fr>
-            <pl>OtwÃƒÂ³rz listÃ„â„¢ pracownikÃƒÂ³w</pl>
+            <pl>OtwÃƒÆ’Ã‚Â³rz listÃƒâ€žÃ¢â€žÂ¢ pracownikÃƒÆ’Ã‚Â³w</pl>
             <es>Abrir lista de trabajadores</es>
             <it>Apri elenco operai</it>
-            <cz>OtevÃ…â„¢ÃƒÂ­t seznam pracovnÃƒÂ­kÃ…Â¯</cz>
+            <cz>OtevÃƒâ€¦Ã¢â€žÂ¢ÃƒÆ’Ã‚Â­t seznam pracovnÃƒÆ’Ã‚Â­kÃƒâ€¦Ã‚Â¯</cz>
             <br>Abrir lista de trabalhadores</br>
-            <uk>Ãâ€™Ã‘â€“ÃÂ´ÃÂºÃ‘â‚¬ÃÂ¸Ã‘â€šÃÂ¸ Ã‘ÂÃÂ¿ÃÂ¸Ã‘ÂÃÂ¾ÃÂº ÃÂ¿Ã‘â‚¬ÃÂ°Ã‘â€ Ã‘â€“ÃÂ²ÃÂ½ÃÂ¸ÃÂºÃ‘â€“ÃÂ²</uk>
-            <ru>ÃÅ¾Ã‘â€šÃÂºÃ‘â‚¬Ã‘â€¹Ã‘â€šÃ‘Å’ Ã‘ÂÃÂ¿ÃÂ¸Ã‘ÂÃÂ¾ÃÂº Ã‘â‚¬ÃÂ°ÃÂ±ÃÂ¾Ã‘â€šÃÂ½ÃÂ¸ÃÂºÃÂ¾ÃÂ²</ru>
-            <da>Ãƒâ€¦bn medarbejderliste</da>
+            <uk>ÃƒÂÃ¢â‚¬â„¢Ãƒâ€˜Ã¢â‚¬â€œÃƒÂÃ‚Â´ÃƒÂÃ‚ÂºÃƒâ€˜Ã¢â€šÂ¬ÃƒÂÃ‚Â¸Ãƒâ€˜Ã¢â‚¬Å¡ÃƒÂÃ‚Â¸ Ãƒâ€˜Ã‚ÂÃƒÂÃ‚Â¿ÃƒÂÃ‚Â¸Ãƒâ€˜Ã‚ÂÃƒÂÃ‚Â¾ÃƒÂÃ‚Âº ÃƒÂÃ‚Â¿Ãƒâ€˜Ã¢â€šÂ¬ÃƒÂÃ‚Â°Ãƒâ€˜Ã¢â‚¬Â Ãƒâ€˜Ã¢â‚¬â€œÃƒÂÃ‚Â²ÃƒÂÃ‚Â½ÃƒÂÃ‚Â¸ÃƒÂÃ‚ÂºÃƒâ€˜Ã¢â‚¬â€œÃƒÂÃ‚Â²</uk>
+            <ru>ÃƒÂÃ…Â¾Ãƒâ€˜Ã¢â‚¬Å¡ÃƒÂÃ‚ÂºÃƒâ€˜Ã¢â€šÂ¬Ãƒâ€˜Ã¢â‚¬Â¹Ãƒâ€˜Ã¢â‚¬Å¡Ãƒâ€˜Ã…â€™ Ãƒâ€˜Ã‚ÂÃƒÂÃ‚Â¿ÃƒÂÃ‚Â¸Ãƒâ€˜Ã‚ÂÃƒÂÃ‚Â¾ÃƒÂÃ‚Âº Ãƒâ€˜Ã¢â€šÂ¬ÃƒÂÃ‚Â°ÃƒÂÃ‚Â±ÃƒÂÃ‚Â¾Ãƒâ€˜Ã¢â‚¬Å¡ÃƒÂÃ‚Â½ÃƒÂÃ‚Â¸ÃƒÂÃ‚ÂºÃƒÂÃ‚Â¾ÃƒÂÃ‚Â²</ru>
+            <da>ÃƒÆ’Ã¢â‚¬Â¦bn medarbejderliste</da>
         </text>
 
         <text name="wc_enabled_short">
             <en>Enable Mod</en>
             <de>Mod aktivieren</de>
             <fr>Activer le mod</fr>
-            <pl>WÃ…â€šÃ„â€¦cz mod</pl>
+            <pl>WÃƒâ€¦Ã¢â‚¬Å¡Ãƒâ€žÃ¢â‚¬Â¦cz mod</pl>
             <es>Activar mod</es>
             <it>Attiva mod</it>
             <cz>Povolit mod</cz>
             <br>Ativar mod</br>
-            <uk>ÃÂ£ÃÂ²Ã‘â€“ÃÂ¼ÃÂºÃÂ½Ã‘Æ’Ã‘â€šÃÂ¸ ÃÂ¼ÃÂ¾ÃÂ´</uk>
-            <ru>Ãâ€™ÃÂºÃÂ»Ã‘Å½Ã‘â€¡ÃÂ¸Ã‘â€šÃ‘Å’ ÃÂ¼ÃÂ¾ÃÂ´</ru>
+            <uk>ÃƒÂÃ‚Â£ÃƒÂÃ‚Â²Ãƒâ€˜Ã¢â‚¬â€œÃƒÂÃ‚Â¼ÃƒÂÃ‚ÂºÃƒÂÃ‚Â½Ãƒâ€˜Ã†â€™Ãƒâ€˜Ã¢â‚¬Å¡ÃƒÂÃ‚Â¸ ÃƒÂÃ‚Â¼ÃƒÂÃ‚Â¾ÃƒÂÃ‚Â´</uk>
+            <ru>ÃƒÂÃ¢â‚¬â„¢ÃƒÂÃ‚ÂºÃƒÂÃ‚Â»Ãƒâ€˜Ã…Â½Ãƒâ€˜Ã¢â‚¬Â¡ÃƒÂÃ‚Â¸Ãƒâ€˜Ã¢â‚¬Å¡Ãƒâ€˜Ã…â€™ ÃƒÂÃ‚Â¼ÃƒÂÃ‚Â¾ÃƒÂÃ‚Â´</ru>
         
             <da>Aktiver Mod</da>
         </text>
@@ -87,16 +87,16 @@
         <text name="wc_enabled_long">
             <en>Enable or disable the worker costs mod</en>
             <de>Arbeiterkosten-Mod aktivieren oder deaktivieren</de>
-            <fr>Activer ou dÃƒÂ©sactiver le module de coÃƒÂ»ts des ouvriers</fr>
-            <pl>WÃ…â€šÃ„â€¦cz lub wyÃ…â€šÃ„â€¦cz mod kosztÃƒÂ³w pracownikÃƒÂ³w</pl>
-            <es>Activar o desactivar el mÃƒÂ³dulo de costos de trabajadores</es>
+            <fr>Activer ou dÃƒÆ’Ã‚Â©sactiver le module de coÃƒÆ’Ã‚Â»ts des ouvriers</fr>
+            <pl>WÃƒâ€¦Ã¢â‚¬Å¡Ãƒâ€žÃ¢â‚¬Â¦cz lub wyÃƒâ€¦Ã¢â‚¬Å¡Ãƒâ€žÃ¢â‚¬Â¦cz mod kosztÃƒÆ’Ã‚Â³w pracownikÃƒÆ’Ã‚Â³w</pl>
+            <es>Activar o desactivar el mÃƒÆ’Ã‚Â³dulo de costos de trabajadores</es>
             <it>Attiva o disattiva il modulo dei costi degli operai</it>
-            <cz>Povolit nebo zakÃƒÂ¡zat mod nÃƒÂ¡kladÃ…Â¯ na pracovnÃƒÂ­ky</cz>
+            <cz>Povolit nebo zakÃƒÆ’Ã‚Â¡zat mod nÃƒÆ’Ã‚Â¡kladÃƒâ€¦Ã‚Â¯ na pracovnÃƒÆ’Ã‚Â­ky</cz>
             <br>Ativar ou desativar o mod de custos de trabalhadores</br>
-            <uk>ÃÂ£ÃÂ²Ã‘â€“ÃÂ¼ÃÂºÃÂ½Ã‘Æ’Ã‘â€šÃÂ¸ ÃÂ°ÃÂ±ÃÂ¾ ÃÂ²ÃÂ¸ÃÂ¼ÃÂºÃÂ½Ã‘Æ’Ã‘â€šÃÂ¸ ÃÂ¼ÃÂ¾ÃÂ´ ÃÂ²ÃÂ¸Ã‘â€šÃ‘â‚¬ÃÂ°Ã‘â€š ÃÂ½ÃÂ° ÃÂ¿Ã‘â‚¬ÃÂ°Ã‘â€ Ã‘â€“ÃÂ²ÃÂ½ÃÂ¸ÃÂºÃ‘â€“ÃÂ²</uk>
-            <ru>Ãâ€™ÃÂºÃÂ»Ã‘Å½Ã‘â€¡ÃÂ¸Ã‘â€šÃ‘Å’ ÃÂ¸ÃÂ»ÃÂ¸ ÃÂ²Ã‘â€¹ÃÂºÃÂ»Ã‘Å½Ã‘â€¡ÃÂ¸Ã‘â€šÃ‘Å’ ÃÂ¼ÃÂ¾ÃÂ´ Ã‘â‚¬ÃÂ°Ã‘ÂÃ‘â€¦ÃÂ¾ÃÂ´ÃÂ¾ÃÂ² ÃÂ½ÃÂ° Ã‘â‚¬ÃÂ°ÃÂ±ÃÂ¾Ã‘â€šÃÂ½ÃÂ¸ÃÂºÃÂ¾ÃÂ²</ru>
+            <uk>ÃƒÂÃ‚Â£ÃƒÂÃ‚Â²Ãƒâ€˜Ã¢â‚¬â€œÃƒÂÃ‚Â¼ÃƒÂÃ‚ÂºÃƒÂÃ‚Â½Ãƒâ€˜Ã†â€™Ãƒâ€˜Ã¢â‚¬Å¡ÃƒÂÃ‚Â¸ ÃƒÂÃ‚Â°ÃƒÂÃ‚Â±ÃƒÂÃ‚Â¾ ÃƒÂÃ‚Â²ÃƒÂÃ‚Â¸ÃƒÂÃ‚Â¼ÃƒÂÃ‚ÂºÃƒÂÃ‚Â½Ãƒâ€˜Ã†â€™Ãƒâ€˜Ã¢â‚¬Å¡ÃƒÂÃ‚Â¸ ÃƒÂÃ‚Â¼ÃƒÂÃ‚Â¾ÃƒÂÃ‚Â´ ÃƒÂÃ‚Â²ÃƒÂÃ‚Â¸Ãƒâ€˜Ã¢â‚¬Å¡Ãƒâ€˜Ã¢â€šÂ¬ÃƒÂÃ‚Â°Ãƒâ€˜Ã¢â‚¬Å¡ ÃƒÂÃ‚Â½ÃƒÂÃ‚Â° ÃƒÂÃ‚Â¿Ãƒâ€˜Ã¢â€šÂ¬ÃƒÂÃ‚Â°Ãƒâ€˜Ã¢â‚¬Â Ãƒâ€˜Ã¢â‚¬â€œÃƒÂÃ‚Â²ÃƒÂÃ‚Â½ÃƒÂÃ‚Â¸ÃƒÂÃ‚ÂºÃƒâ€˜Ã¢â‚¬â€œÃƒÂÃ‚Â²</uk>
+            <ru>ÃƒÂÃ¢â‚¬â„¢ÃƒÂÃ‚ÂºÃƒÂÃ‚Â»Ãƒâ€˜Ã…Â½Ãƒâ€˜Ã¢â‚¬Â¡ÃƒÂÃ‚Â¸Ãƒâ€˜Ã¢â‚¬Å¡Ãƒâ€˜Ã…â€™ ÃƒÂÃ‚Â¸ÃƒÂÃ‚Â»ÃƒÂÃ‚Â¸ ÃƒÂÃ‚Â²Ãƒâ€˜Ã¢â‚¬Â¹ÃƒÂÃ‚ÂºÃƒÂÃ‚Â»Ãƒâ€˜Ã…Â½Ãƒâ€˜Ã¢â‚¬Â¡ÃƒÂÃ‚Â¸Ãƒâ€˜Ã¢â‚¬Å¡Ãƒâ€˜Ã…â€™ ÃƒÂÃ‚Â¼ÃƒÂÃ‚Â¾ÃƒÂÃ‚Â´ Ãƒâ€˜Ã¢â€šÂ¬ÃƒÂÃ‚Â°Ãƒâ€˜Ã‚ÂÃƒâ€˜Ã¢â‚¬Â¦ÃƒÂÃ‚Â¾ÃƒÂÃ‚Â´ÃƒÂÃ‚Â¾ÃƒÂÃ‚Â² ÃƒÂÃ‚Â½ÃƒÂÃ‚Â° Ãƒâ€˜Ã¢â€šÂ¬ÃƒÂÃ‚Â°ÃƒÂÃ‚Â±ÃƒÂÃ‚Â¾Ãƒâ€˜Ã¢â‚¬Å¡ÃƒÂÃ‚Â½ÃƒÂÃ‚Â¸ÃƒÂÃ‚ÂºÃƒÂÃ‚Â¾ÃƒÂÃ‚Â²</ru>
         
-            <da>AktivÃƒÂ©r eller deaktiver modÃ¢â‚¬â„¢en for medarbejderomkostninger</da>
+            <da>AktivÃƒÆ’Ã‚Â©r eller deaktiver modÃƒÂ¢Ã¢â€šÂ¬Ã¢â€žÂ¢en for medarbejderomkostninger</da>
         </text>
         
         <text name="wc_debug_short">
@@ -105,57 +105,57 @@
             <fr>Mode DEBUG</fr>
             <pl>Tryb DEBUG</pl>
             <es>Modo DEBUG</es>
-            <it>ModalitÃƒÂ  DEBUG</it>
-            <cz>DEBUG reÃ…Â¾im</cz>
+            <it>ModalitÃƒÆ’Ã‚Â  DEBUG</it>
+            <cz>DEBUG reÃƒâ€¦Ã‚Â¾im</cz>
             <br>Modo DEBUG</br>
-            <uk>ÃÂ ÃÂµÃÂ¶ÃÂ¸ÃÂ¼ DEBUG</uk>
-            <ru>ÃÂ ÃÂµÃÂ¶ÃÂ¸ÃÂ¼ DEBUG</ru>
+            <uk>ÃƒÂÃ‚Â ÃƒÂÃ‚ÂµÃƒÂÃ‚Â¶ÃƒÂÃ‚Â¸ÃƒÂÃ‚Â¼ DEBUG</uk>
+            <ru>ÃƒÂÃ‚Â ÃƒÂÃ‚ÂµÃƒÂÃ‚Â¶ÃƒÂÃ‚Â¸ÃƒÂÃ‚Â¼ DEBUG</ru>
         
             <da>Debug-tilstand</da>
         </text>
         
         <text name="wc_debug_long">
             <en>Enable/disable debug mode (extra logging)</en>
-            <de>DEBUG-Modus ein-/ausschalten (zusÃƒÂ¤tzliche Protokollierung)</de>
-            <fr>Activer/dÃƒÂ©sactiver le mode DEBUG (journalisation supplÃƒÂ©mentaire)</fr>
-            <pl>WÃ…â€šÃ„â€¦cz/wyÃ…â€šÃ„â€¦cz tryb DEBUG (dodatkowe logowanie)</pl>
+            <de>DEBUG-Modus ein-/ausschalten (zusÃƒÆ’Ã‚Â¤tzliche Protokollierung)</de>
+            <fr>Activer/dÃƒÆ’Ã‚Â©sactiver le mode DEBUG (journalisation supplÃƒÆ’Ã‚Â©mentaire)</fr>
+            <pl>WÃƒâ€¦Ã¢â‚¬Å¡Ãƒâ€žÃ¢â‚¬Â¦cz/wyÃƒâ€¦Ã¢â‚¬Å¡Ãƒâ€žÃ¢â‚¬Â¦cz tryb DEBUG (dodatkowe logowanie)</pl>
             <es>Activar/desactivar modo DEBUG (registro adicional)</es>
-            <it>Attiva/disattiva modalitÃƒÂ  DEBUG (registrazione aggiuntiva)</it>
-            <cz>Povolit/zakÃƒÂ¡zat DEBUG reÃ…Â¾im (dodateÃ„ÂnÃƒÂ© logovÃƒÂ¡nÃƒÂ­)</cz>
+            <it>Attiva/disattiva modalitÃƒÆ’Ã‚Â  DEBUG (registrazione aggiuntiva)</it>
+            <cz>Povolit/zakÃƒÆ’Ã‚Â¡zat DEBUG reÃƒâ€¦Ã‚Â¾im (dodateÃƒâ€žÃ‚ÂnÃƒÆ’Ã‚Â© logovÃƒÆ’Ã‚Â¡nÃƒÆ’Ã‚Â­)</cz>
             <br>Ativar/desativar modo DEBUG (registro adicional)</br>
-            <uk>ÃÂ£ÃÂ²Ã‘â€“ÃÂ¼ÃÂºÃÂ½Ã‘Æ’Ã‘â€šÃÂ¸/ÃÂ²ÃÂ¸ÃÂ¼ÃÂºÃÂ½Ã‘Æ’Ã‘â€šÃÂ¸ Ã‘â‚¬ÃÂµÃÂ¶ÃÂ¸ÃÂ¼ DEBUG (ÃÂ´ÃÂ¾ÃÂ´ÃÂ°Ã‘â€šÃÂºÃÂ¾ÃÂ²ÃÂµ ÃÂ»ÃÂ¾ÃÂ³Ã‘Æ’ÃÂ²ÃÂ°ÃÂ½ÃÂ½Ã‘Â)</uk>
-            <ru>Ãâ€™ÃÂºÃÂ»Ã‘Å½Ã‘â€¡ÃÂ¸Ã‘â€šÃ‘Å’/ÃÂ²Ã‘â€¹ÃÂºÃÂ»Ã‘Å½Ã‘â€¡ÃÂ¸Ã‘â€šÃ‘Å’ Ã‘â‚¬ÃÂµÃÂ¶ÃÂ¸ÃÂ¼ DEBUG (ÃÂ´ÃÂ¾ÃÂ¿ÃÂ¾ÃÂ»ÃÂ½ÃÂ¸Ã‘â€šÃÂµÃÂ»Ã‘Å’ÃÂ½ÃÂ¾ÃÂµ ÃÂ»ÃÂ¾ÃÂ³ÃÂ¸Ã‘â‚¬ÃÂ¾ÃÂ²ÃÂ°ÃÂ½ÃÂ¸ÃÂµ)</ru>
+            <uk>ÃƒÂÃ‚Â£ÃƒÂÃ‚Â²Ãƒâ€˜Ã¢â‚¬â€œÃƒÂÃ‚Â¼ÃƒÂÃ‚ÂºÃƒÂÃ‚Â½Ãƒâ€˜Ã†â€™Ãƒâ€˜Ã¢â‚¬Å¡ÃƒÂÃ‚Â¸/ÃƒÂÃ‚Â²ÃƒÂÃ‚Â¸ÃƒÂÃ‚Â¼ÃƒÂÃ‚ÂºÃƒÂÃ‚Â½Ãƒâ€˜Ã†â€™Ãƒâ€˜Ã¢â‚¬Å¡ÃƒÂÃ‚Â¸ Ãƒâ€˜Ã¢â€šÂ¬ÃƒÂÃ‚ÂµÃƒÂÃ‚Â¶ÃƒÂÃ‚Â¸ÃƒÂÃ‚Â¼ DEBUG (ÃƒÂÃ‚Â´ÃƒÂÃ‚Â¾ÃƒÂÃ‚Â´ÃƒÂÃ‚Â°Ãƒâ€˜Ã¢â‚¬Å¡ÃƒÂÃ‚ÂºÃƒÂÃ‚Â¾ÃƒÂÃ‚Â²ÃƒÂÃ‚Âµ ÃƒÂÃ‚Â»ÃƒÂÃ‚Â¾ÃƒÂÃ‚Â³Ãƒâ€˜Ã†â€™ÃƒÂÃ‚Â²ÃƒÂÃ‚Â°ÃƒÂÃ‚Â½ÃƒÂÃ‚Â½Ãƒâ€˜Ã‚Â)</uk>
+            <ru>ÃƒÂÃ¢â‚¬â„¢ÃƒÂÃ‚ÂºÃƒÂÃ‚Â»Ãƒâ€˜Ã…Â½Ãƒâ€˜Ã¢â‚¬Â¡ÃƒÂÃ‚Â¸Ãƒâ€˜Ã¢â‚¬Å¡Ãƒâ€˜Ã…â€™/ÃƒÂÃ‚Â²Ãƒâ€˜Ã¢â‚¬Â¹ÃƒÂÃ‚ÂºÃƒÂÃ‚Â»Ãƒâ€˜Ã…Â½Ãƒâ€˜Ã¢â‚¬Â¡ÃƒÂÃ‚Â¸Ãƒâ€˜Ã¢â‚¬Å¡Ãƒâ€˜Ã…â€™ Ãƒâ€˜Ã¢â€šÂ¬ÃƒÂÃ‚ÂµÃƒÂÃ‚Â¶ÃƒÂÃ‚Â¸ÃƒÂÃ‚Â¼ DEBUG (ÃƒÂÃ‚Â´ÃƒÂÃ‚Â¾ÃƒÂÃ‚Â¿ÃƒÂÃ‚Â¾ÃƒÂÃ‚Â»ÃƒÂÃ‚Â½ÃƒÂÃ‚Â¸Ãƒâ€˜Ã¢â‚¬Å¡ÃƒÂÃ‚ÂµÃƒÂÃ‚Â»Ãƒâ€˜Ã…â€™ÃƒÂÃ‚Â½ÃƒÂÃ‚Â¾ÃƒÂÃ‚Âµ ÃƒÂÃ‚Â»ÃƒÂÃ‚Â¾ÃƒÂÃ‚Â³ÃƒÂÃ‚Â¸Ãƒâ€˜Ã¢â€šÂ¬ÃƒÂÃ‚Â¾ÃƒÂÃ‚Â²ÃƒÂÃ‚Â°ÃƒÂÃ‚Â½ÃƒÂÃ‚Â¸ÃƒÂÃ‚Âµ)</ru>
         
-            <da>SlÃƒÂ¥ debug-tilstand til/fra (ekstra logning)</da>
+            <da>SlÃƒÆ’Ã‚Â¥ debug-tilstand til/fra (ekstra logning)</da>
         </text>
         
         
         <text name="wc_costmode_long">
             <en>Choose cost calculation: hourly or per hectare</en>
-            <de>WÃƒÂ¤hlen Sie die Kostenberechnung: stÃƒÂ¼ndlich oder pro Hektar</de>
-            <fr>Choisissez le calcul des coÃƒÂ»ts : horaire ou par hectare</fr>
-            <pl>Wybierz obliczanie kosztÃƒÂ³w: godzinowe lub za hektar</pl>
-            <es>Elegir cÃƒÂ¡lculo de costos: por hora o por hectÃƒÂ¡rea</es>
+            <de>WÃƒÆ’Ã‚Â¤hlen Sie die Kostenberechnung: stÃƒÆ’Ã‚Â¼ndlich oder pro Hektar</de>
+            <fr>Choisissez le calcul des coÃƒÆ’Ã‚Â»ts : horaire ou par hectare</fr>
+            <pl>Wybierz obliczanie kosztÃƒÆ’Ã‚Â³w: godzinowe lub za hektar</pl>
+            <es>Elegir cÃƒÆ’Ã‚Â¡lculo de costos: por hora o por hectÃƒÆ’Ã‚Â¡rea</es>
             <it>Scegli calcolo costi: orario o per ettaro</it>
-            <cz>Vyberte vÃƒÂ½poÃ„Âet nÃƒÂ¡kladÃ…Â¯: hodinovÃƒÂ½ nebo na hektar</cz>
-            <br>Escolher cÃƒÂ¡lculo de custos: por hora ou por hectare</br>
-            <uk>Ãâ€™ÃÂ¸ÃÂ±ÃÂµÃ‘â‚¬Ã‘â€“Ã‘â€šÃ‘Å’ Ã‘â‚¬ÃÂ¾ÃÂ·Ã‘â‚¬ÃÂ°Ã‘â€¦Ã‘Æ’ÃÂ½ÃÂ¾ÃÂº ÃÂ²ÃÂ¸Ã‘â€šÃ‘â‚¬ÃÂ°Ã‘â€š: ÃÂ¿ÃÂ¾ÃÂ³ÃÂ¾ÃÂ´ÃÂ¸ÃÂ½ÃÂ½ÃÂ¾ ÃÂ°ÃÂ±ÃÂ¾ ÃÂ·ÃÂ° ÃÂ³ÃÂµÃÂºÃ‘â€šÃÂ°Ã‘â‚¬</uk>
-            <ru>Ãâ€™Ã‘â€¹ÃÂ±Ã‘â‚¬ÃÂ°Ã‘â€šÃ‘Å’ Ã‘â‚¬ÃÂ°Ã‘ÂÃ‘â€¡ÃÂµÃ‘â€š Ã‘â‚¬ÃÂ°Ã‘ÂÃ‘â€¦ÃÂ¾ÃÂ´ÃÂ¾ÃÂ²: ÃÂ¿ÃÂ¾Ã‘â€¡ÃÂ°Ã‘ÂÃÂ¾ÃÂ²ÃÂ¾ ÃÂ¸ÃÂ»ÃÂ¸ ÃÂ·ÃÂ° ÃÂ³ÃÂµÃÂºÃ‘â€šÃÂ°Ã‘â‚¬</ru>
+            <cz>Vyberte vÃƒÆ’Ã‚Â½poÃƒâ€žÃ‚Âet nÃƒÆ’Ã‚Â¡kladÃƒâ€¦Ã‚Â¯: hodinovÃƒÆ’Ã‚Â½ nebo na hektar</cz>
+            <br>Escolher cÃƒÆ’Ã‚Â¡lculo de custos: por hora ou por hectare</br>
+            <uk>ÃƒÂÃ¢â‚¬â„¢ÃƒÂÃ‚Â¸ÃƒÂÃ‚Â±ÃƒÂÃ‚ÂµÃƒâ€˜Ã¢â€šÂ¬Ãƒâ€˜Ã¢â‚¬â€œÃƒâ€˜Ã¢â‚¬Å¡Ãƒâ€˜Ã…â€™ Ãƒâ€˜Ã¢â€šÂ¬ÃƒÂÃ‚Â¾ÃƒÂÃ‚Â·Ãƒâ€˜Ã¢â€šÂ¬ÃƒÂÃ‚Â°Ãƒâ€˜Ã¢â‚¬Â¦Ãƒâ€˜Ã†â€™ÃƒÂÃ‚Â½ÃƒÂÃ‚Â¾ÃƒÂÃ‚Âº ÃƒÂÃ‚Â²ÃƒÂÃ‚Â¸Ãƒâ€˜Ã¢â‚¬Å¡Ãƒâ€˜Ã¢â€šÂ¬ÃƒÂÃ‚Â°Ãƒâ€˜Ã¢â‚¬Å¡: ÃƒÂÃ‚Â¿ÃƒÂÃ‚Â¾ÃƒÂÃ‚Â³ÃƒÂÃ‚Â¾ÃƒÂÃ‚Â´ÃƒÂÃ‚Â¸ÃƒÂÃ‚Â½ÃƒÂÃ‚Â½ÃƒÂÃ‚Â¾ ÃƒÂÃ‚Â°ÃƒÂÃ‚Â±ÃƒÂÃ‚Â¾ ÃƒÂÃ‚Â·ÃƒÂÃ‚Â° ÃƒÂÃ‚Â³ÃƒÂÃ‚ÂµÃƒÂÃ‚ÂºÃƒâ€˜Ã¢â‚¬Å¡ÃƒÂÃ‚Â°Ãƒâ€˜Ã¢â€šÂ¬</uk>
+            <ru>ÃƒÂÃ¢â‚¬â„¢Ãƒâ€˜Ã¢â‚¬Â¹ÃƒÂÃ‚Â±Ãƒâ€˜Ã¢â€šÂ¬ÃƒÂÃ‚Â°Ãƒâ€˜Ã¢â‚¬Å¡Ãƒâ€˜Ã…â€™ Ãƒâ€˜Ã¢â€šÂ¬ÃƒÂÃ‚Â°Ãƒâ€˜Ã‚ÂÃƒâ€˜Ã¢â‚¬Â¡ÃƒÂÃ‚ÂµÃƒâ€˜Ã¢â‚¬Å¡ Ãƒâ€˜Ã¢â€šÂ¬ÃƒÂÃ‚Â°Ãƒâ€˜Ã‚ÂÃƒâ€˜Ã¢â‚¬Â¦ÃƒÂÃ‚Â¾ÃƒÂÃ‚Â´ÃƒÂÃ‚Â¾ÃƒÂÃ‚Â²: ÃƒÂÃ‚Â¿ÃƒÂÃ‚Â¾Ãƒâ€˜Ã¢â‚¬Â¡ÃƒÂÃ‚Â°Ãƒâ€˜Ã‚ÂÃƒÂÃ‚Â¾ÃƒÂÃ‚Â²ÃƒÂÃ‚Â¾ ÃƒÂÃ‚Â¸ÃƒÂÃ‚Â»ÃƒÂÃ‚Â¸ ÃƒÂÃ‚Â·ÃƒÂÃ‚Â° ÃƒÂÃ‚Â³ÃƒÂÃ‚ÂµÃƒÂÃ‚ÂºÃƒâ€˜Ã¢â‚¬Å¡ÃƒÂÃ‚Â°Ãƒâ€˜Ã¢â€šÂ¬</ru>
         
-            <da>VÃƒÂ¦lg beregningsmetode for omkostninger: timebaseret eller pr. hektar</da>
+            <da>VÃƒÆ’Ã‚Â¦lg beregningsmetode for omkostninger: timebaseret eller pr. hektar</da>
         </text>
         
         <text name="wc_costmode_1">
             <en>Hourly ($/h)</en>
-            <de>StÃƒÂ¼ndlich ($/h)</de>
+            <de>StÃƒÆ’Ã‚Â¼ndlich ($/h)</de>
             <fr>Horaire ($/h)</fr>
             <pl>Godzinowe ($/h)</pl>
             <es>Por hora ($/h)</es>
             <it>Orario ($/h)</it>
-            <cz>HodinovÃƒÂ© ($/h)</cz>
+            <cz>HodinovÃƒÆ’Ã‚Â© ($/h)</cz>
             <br>Por hora ($/h)</br>
-            <uk>ÃÅ¸ÃÂ¾ÃÂ³ÃÂ¾ÃÂ´ÃÂ¸ÃÂ½ÃÂ½ÃÂ¾ ($/ÃÂ³ÃÂ¾ÃÂ´)</uk>
-            <ru>ÃÅ¸ÃÂ¾Ã‘â€¡ÃÂ°Ã‘ÂÃÂ¾ÃÂ²ÃÂ¾ ($/Ã‘â€¡)</ru>
+            <uk>ÃƒÂÃ…Â¸ÃƒÂÃ‚Â¾ÃƒÂÃ‚Â³ÃƒÂÃ‚Â¾ÃƒÂÃ‚Â´ÃƒÂÃ‚Â¸ÃƒÂÃ‚Â½ÃƒÂÃ‚Â½ÃƒÂÃ‚Â¾ ($/ÃƒÂÃ‚Â³ÃƒÂÃ‚Â¾ÃƒÂÃ‚Â´)</uk>
+            <ru>ÃƒÂÃ…Â¸ÃƒÂÃ‚Â¾Ãƒâ€˜Ã¢â‚¬Â¡ÃƒÂÃ‚Â°Ãƒâ€˜Ã‚ÂÃƒÂÃ‚Â¾ÃƒÂÃ‚Â²ÃƒÂÃ‚Â¾ ($/Ãƒâ€˜Ã¢â‚¬Â¡)</ru>
         
             <da>Timebaseret ($/t)</da>
         </text>
@@ -165,12 +165,12 @@
             <de>Pro Hektar ($/ha)</de>
             <fr>Par hectare ($/ha)</fr>
             <pl>Za hektar ($/ha)</pl>
-            <es>Por hectÃƒÂ¡rea ($/ha)</es>
+            <es>Por hectÃƒÆ’Ã‚Â¡rea ($/ha)</es>
             <it>Per ettaro ($/ha)</it>
             <cz>Na hektar ($/ha)</cz>
             <br>Por hectare ($/ha)</br>
-            <uk>Ãâ€”ÃÂ° ÃÂ³ÃÂµÃÂºÃ‘â€šÃÂ°Ã‘â‚¬ ($/ÃÂ³ÃÂ°)</uk>
-            <ru>Ãâ€”ÃÂ° ÃÂ³ÃÂµÃÂºÃ‘â€šÃÂ°Ã‘â‚¬ ($/ÃÂ³ÃÂ°)</ru>
+            <uk>ÃƒÂÃ¢â‚¬â€ÃƒÂÃ‚Â° ÃƒÂÃ‚Â³ÃƒÂÃ‚ÂµÃƒÂÃ‚ÂºÃƒâ€˜Ã¢â‚¬Å¡ÃƒÂÃ‚Â°Ãƒâ€˜Ã¢â€šÂ¬ ($/ÃƒÂÃ‚Â³ÃƒÂÃ‚Â°)</uk>
+            <ru>ÃƒÂÃ¢â‚¬â€ÃƒÂÃ‚Â° ÃƒÂÃ‚Â³ÃƒÂÃ‚ÂµÃƒÂÃ‚ÂºÃƒâ€˜Ã¢â‚¬Å¡ÃƒÂÃ‚Â°Ãƒâ€˜Ã¢â€šÂ¬ ($/ÃƒÂÃ‚Â³ÃƒÂÃ‚Â°)</ru>
         
             <da>Pr. hektar ($/ha)</da>
         </text>
@@ -179,31 +179,31 @@
             <en>Monthly Salary</en>
             <de>Monatliches Gehalt</de>
             <fr>Salaire Mensuel</fr>
-            <pl>MiesiÃ„â„¢czne Wynagrodzenie</pl>
+            <pl>MiesiÃƒâ€žÃ¢â€žÂ¢czne Wynagrodzenie</pl>
             <es>Salario Mensual</es>
             <it>Stipendio Mensile</it>
-            <cz>MÃ„â€ºsÃƒÂ­Ã„ÂnÃƒÂ­ plat</cz>
-            <br>SalÃƒÂ¡rio Mensal</br>
-            <uk>ÃÂ©ÃÂ¾ÃÂ¼Ã‘â€“Ã‘ÂÃ‘ÂÃ‘â€¡ÃÂ½ÃÂ° ÃÂ·ÃÂ°Ã‘â‚¬ÃÂ¾ÃÂ±Ã‘â€“Ã‘â€šÃÂ½ÃÂ° ÃÂ¿ÃÂ»ÃÂ°Ã‘â€šÃÂ°</uk>
-            <ru>Ãâ€¢ÃÂ¶ÃÂµÃÂ¼ÃÂµÃ‘ÂÃ‘ÂÃ‘â€¡ÃÂ½ÃÂ°Ã‘Â ÃÂ·ÃÂ°Ã‘â‚¬ÃÂ¿ÃÂ»ÃÂ°Ã‘â€šÃÂ°</ru>
+            <cz>MÃƒâ€žÃ¢â‚¬ÂºsÃƒÆ’Ã‚Â­Ãƒâ€žÃ‚ÂnÃƒÆ’Ã‚Â­ plat</cz>
+            <br>SalÃƒÆ’Ã‚Â¡rio Mensal</br>
+            <uk>ÃƒÂÃ‚Â©ÃƒÂÃ‚Â¾ÃƒÂÃ‚Â¼Ãƒâ€˜Ã¢â‚¬â€œÃƒâ€˜Ã‚ÂÃƒâ€˜Ã‚ÂÃƒâ€˜Ã¢â‚¬Â¡ÃƒÂÃ‚Â½ÃƒÂÃ‚Â° ÃƒÂÃ‚Â·ÃƒÂÃ‚Â°Ãƒâ€˜Ã¢â€šÂ¬ÃƒÂÃ‚Â¾ÃƒÂÃ‚Â±Ãƒâ€˜Ã¢â‚¬â€œÃƒâ€˜Ã¢â‚¬Å¡ÃƒÂÃ‚Â½ÃƒÂÃ‚Â° ÃƒÂÃ‚Â¿ÃƒÂÃ‚Â»ÃƒÂÃ‚Â°Ãƒâ€˜Ã¢â‚¬Å¡ÃƒÂÃ‚Â°</uk>
+            <ru>ÃƒÂÃ¢â‚¬Â¢ÃƒÂÃ‚Â¶ÃƒÂÃ‚ÂµÃƒÂÃ‚Â¼ÃƒÂÃ‚ÂµÃƒâ€˜Ã‚ÂÃƒâ€˜Ã‚ÂÃƒâ€˜Ã¢â‚¬Â¡ÃƒÂÃ‚Â½ÃƒÂÃ‚Â°Ãƒâ€˜Ã‚Â ÃƒÂÃ‚Â·ÃƒÂÃ‚Â°Ãƒâ€˜Ã¢â€šÂ¬ÃƒÂÃ‚Â¿ÃƒÂÃ‚Â»ÃƒÂÃ‚Â°Ãƒâ€˜Ã¢â‚¬Å¡ÃƒÂÃ‚Â°</ru>
         
-            <da>MÃƒÂ¥nedslÃƒÂ¸n</da>
+            <da>MÃƒÆ’Ã‚Â¥nedslÃƒÆ’Ã‚Â¸n</da>
         </text>
 
         
         <text name="wc_difficulty_long">
             <en>Set base wage rate: Low=$15/h, Medium=$25/h, High=$40/h</en>
             <de>Grundlohnsatz festlegen: Niedrig=15$/h, Mittel=25$/h, Hoch=40$/h</de>
-            <fr>DÃƒÂ©finir le taux de salaire de base : Bas=15$/h, Moyen=25$/h, Ãƒâ€°levÃƒÂ©=40$/h</fr>
-            <pl>Ustaw podstawowÃ„â€¦ stawkÃ„â„¢: Niska=15$/h, Ã…Å¡rednia=25$/h, Wysoka=40$/h</pl>
+            <fr>DÃƒÆ’Ã‚Â©finir le taux de salaire de base : Bas=15$/h, Moyen=25$/h, ÃƒÆ’Ã¢â‚¬Â°levÃƒÆ’Ã‚Â©=40$/h</fr>
+            <pl>Ustaw podstawowÃƒâ€žÃ¢â‚¬Â¦ stawkÃƒâ€žÃ¢â€žÂ¢: Niska=15$/h, Ãƒâ€¦Ã…Â¡rednia=25$/h, Wysoka=40$/h</pl>
             <es>Establecer tasa salarial base: Baja=15$/h, Media=25$/h, Alta=40$/h</es>
             <it>Imposta tariffa base: Bassa=15$/h, Media=25$/h, Alta=40$/h</it>
-            <cz>Nastavit zÃƒÂ¡kladnÃƒÂ­ sazbu: NÃƒÂ­zkÃƒÂ¡=15$/h, StÃ…â„¢ednÃƒÂ­=25$/h, VysokÃƒÂ¡=40$/h</cz>
-            <br>Definir taxa salarial base: Baixa=15$/h, MÃƒÂ©dia=25$/h, Alta=40$/h</br>
-            <uk>Ãâ€™Ã‘ÂÃ‘â€šÃÂ°ÃÂ½ÃÂ¾ÃÂ²ÃÂ¸Ã‘â€šÃÂ¸ ÃÂ±ÃÂ°ÃÂ·ÃÂ¾ÃÂ²Ã‘Æ’ Ã‘ÂÃ‘â€šÃÂ°ÃÂ²ÃÂºÃ‘Æ’: ÃÂÃÂ¸ÃÂ·Ã‘Å’ÃÂºÃÂ°=15$/ÃÂ³ÃÂ¾ÃÂ´, ÃÂ¡ÃÂµÃ‘â‚¬ÃÂµÃÂ´ÃÂ½Ã‘Â=25$/ÃÂ³ÃÂ¾ÃÂ´, Ãâ€™ÃÂ¸Ã‘ÂÃÂ¾ÃÂºÃÂ°=40$/ÃÂ³ÃÂ¾ÃÂ´</uk>
-            <ru>ÃÂ£Ã‘ÂÃ‘â€šÃÂ°ÃÂ½ÃÂ¾ÃÂ²ÃÂ¸Ã‘â€šÃ‘Å’ ÃÂ±ÃÂ°ÃÂ·ÃÂ¾ÃÂ²Ã‘Æ’Ã‘Å½ Ã‘ÂÃ‘â€šÃÂ°ÃÂ²ÃÂºÃ‘Æ’: ÃÂÃÂ¸ÃÂ·ÃÂºÃÂ°Ã‘Â=15$/Ã‘â€¡, ÃÂ¡Ã‘â‚¬ÃÂµÃÂ´ÃÂ½Ã‘ÂÃ‘Â=25$/Ã‘â€¡, Ãâ€™Ã‘â€¹Ã‘ÂÃÂ¾ÃÂºÃÂ°Ã‘Â=40$/Ã‘â€¡</ru>
+            <cz>Nastavit zÃƒÆ’Ã‚Â¡kladnÃƒÆ’Ã‚Â­ sazbu: NÃƒÆ’Ã‚Â­zkÃƒÆ’Ã‚Â¡=15$/h, StÃƒâ€¦Ã¢â€žÂ¢ednÃƒÆ’Ã‚Â­=25$/h, VysokÃƒÆ’Ã‚Â¡=40$/h</cz>
+            <br>Definir taxa salarial base: Baixa=15$/h, MÃƒÆ’Ã‚Â©dia=25$/h, Alta=40$/h</br>
+            <uk>ÃƒÂÃ¢â‚¬â„¢Ãƒâ€˜Ã‚ÂÃƒâ€˜Ã¢â‚¬Å¡ÃƒÂÃ‚Â°ÃƒÂÃ‚Â½ÃƒÂÃ‚Â¾ÃƒÂÃ‚Â²ÃƒÂÃ‚Â¸Ãƒâ€˜Ã¢â‚¬Å¡ÃƒÂÃ‚Â¸ ÃƒÂÃ‚Â±ÃƒÂÃ‚Â°ÃƒÂÃ‚Â·ÃƒÂÃ‚Â¾ÃƒÂÃ‚Â²Ãƒâ€˜Ã†â€™ Ãƒâ€˜Ã‚ÂÃƒâ€˜Ã¢â‚¬Å¡ÃƒÂÃ‚Â°ÃƒÂÃ‚Â²ÃƒÂÃ‚ÂºÃƒâ€˜Ã†â€™: ÃƒÂÃ‚ÂÃƒÂÃ‚Â¸ÃƒÂÃ‚Â·Ãƒâ€˜Ã…â€™ÃƒÂÃ‚ÂºÃƒÂÃ‚Â°=15$/ÃƒÂÃ‚Â³ÃƒÂÃ‚Â¾ÃƒÂÃ‚Â´, ÃƒÂÃ‚Â¡ÃƒÂÃ‚ÂµÃƒâ€˜Ã¢â€šÂ¬ÃƒÂÃ‚ÂµÃƒÂÃ‚Â´ÃƒÂÃ‚Â½Ãƒâ€˜Ã‚Â=25$/ÃƒÂÃ‚Â³ÃƒÂÃ‚Â¾ÃƒÂÃ‚Â´, ÃƒÂÃ¢â‚¬â„¢ÃƒÂÃ‚Â¸Ãƒâ€˜Ã‚ÂÃƒÂÃ‚Â¾ÃƒÂÃ‚ÂºÃƒÂÃ‚Â°=40$/ÃƒÂÃ‚Â³ÃƒÂÃ‚Â¾ÃƒÂÃ‚Â´</uk>
+            <ru>ÃƒÂÃ‚Â£Ãƒâ€˜Ã‚ÂÃƒâ€˜Ã¢â‚¬Å¡ÃƒÂÃ‚Â°ÃƒÂÃ‚Â½ÃƒÂÃ‚Â¾ÃƒÂÃ‚Â²ÃƒÂÃ‚Â¸Ãƒâ€˜Ã¢â‚¬Å¡Ãƒâ€˜Ã…â€™ ÃƒÂÃ‚Â±ÃƒÂÃ‚Â°ÃƒÂÃ‚Â·ÃƒÂÃ‚Â¾ÃƒÂÃ‚Â²Ãƒâ€˜Ã†â€™Ãƒâ€˜Ã…Â½ Ãƒâ€˜Ã‚ÂÃƒâ€˜Ã¢â‚¬Å¡ÃƒÂÃ‚Â°ÃƒÂÃ‚Â²ÃƒÂÃ‚ÂºÃƒâ€˜Ã†â€™: ÃƒÂÃ‚ÂÃƒÂÃ‚Â¸ÃƒÂÃ‚Â·ÃƒÂÃ‚ÂºÃƒÂÃ‚Â°Ãƒâ€˜Ã‚Â=15$/Ãƒâ€˜Ã¢â‚¬Â¡, ÃƒÂÃ‚Â¡Ãƒâ€˜Ã¢â€šÂ¬ÃƒÂÃ‚ÂµÃƒÂÃ‚Â´ÃƒÂÃ‚Â½Ãƒâ€˜Ã‚ÂÃƒâ€˜Ã‚Â=25$/Ãƒâ€˜Ã¢â‚¬Â¡, ÃƒÂÃ¢â‚¬â„¢Ãƒâ€˜Ã¢â‚¬Â¹Ãƒâ€˜Ã‚ÂÃƒÂÃ‚Â¾ÃƒÂÃ‚ÂºÃƒÂÃ‚Â°Ãƒâ€˜Ã‚Â=40$/Ãƒâ€˜Ã¢â‚¬Â¡</ru>
         
-            <da>Angiv basislÃƒÂ¸nsats: Lav=$15/t, Mellem=$25/t, HÃƒÂ¸j=$40/t</da>
+            <da>Angiv basislÃƒÆ’Ã‚Â¸nsats: Lav=$15/t, Mellem=$25/t, HÃƒÆ’Ã‚Â¸j=$40/t</da>
         </text>
         
         <text name="wc_diff_1">
@@ -213,10 +213,10 @@
             <pl>Niska (15$/h)</pl>
             <es>Baja (15$/h)</es>
             <it>Bassa (15$/h)</it>
-            <cz>NÃƒÂ­zkÃƒÂ¡ (15$/h)</cz>
+            <cz>NÃƒÆ’Ã‚Â­zkÃƒÆ’Ã‚Â¡ (15$/h)</cz>
             <br>Baixa (15$/h)</br>
-            <uk>ÃÂÃÂ¸ÃÂ·Ã‘Å’ÃÂºÃÂ° (15$/ÃÂ³ÃÂ¾ÃÂ´)</uk>
-            <ru>ÃÂÃÂ¸ÃÂ·ÃÂºÃÂ°Ã‘Â (15$/Ã‘â€¡)</ru>
+            <uk>ÃƒÂÃ‚ÂÃƒÂÃ‚Â¸ÃƒÂÃ‚Â·Ãƒâ€˜Ã…â€™ÃƒÂÃ‚ÂºÃƒÂÃ‚Â° (15$/ÃƒÂÃ‚Â³ÃƒÂÃ‚Â¾ÃƒÂÃ‚Â´)</uk>
+            <ru>ÃƒÂÃ‚ÂÃƒÂÃ‚Â¸ÃƒÂÃ‚Â·ÃƒÂÃ‚ÂºÃƒÂÃ‚Â°Ãƒâ€˜Ã‚Â (15$/Ãƒâ€˜Ã¢â‚¬Â¡)</ru>
         
             <da>Lav ($15/t)</da>
         </text>
@@ -225,13 +225,13 @@
             <en>Medium ($25/h)</en>
             <de>Mittel (25$/h)</de>
             <fr>Moyen (25$/h)</fr>
-            <pl>Ã…Å¡rednia (25$/h)</pl>
+            <pl>Ãƒâ€¦Ã…Â¡rednia (25$/h)</pl>
             <es>Media (25$/h)</es>
             <it>Media (25$/h)</it>
-            <cz>StÃ…â„¢ednÃƒÂ­ (25$/h)</cz>
-            <br>MÃƒÂ©dia (25$/h)</br>
-            <uk>ÃÂ¡ÃÂµÃ‘â‚¬ÃÂµÃÂ´ÃÂ½Ã‘Â (25$/ÃÂ³ÃÂ¾ÃÂ´)</uk>
-            <ru>ÃÂ¡Ã‘â‚¬ÃÂµÃÂ´ÃÂ½Ã‘ÂÃ‘Â (25$/Ã‘â€¡)</ru>
+            <cz>StÃƒâ€¦Ã¢â€žÂ¢ednÃƒÆ’Ã‚Â­ (25$/h)</cz>
+            <br>MÃƒÆ’Ã‚Â©dia (25$/h)</br>
+            <uk>ÃƒÂÃ‚Â¡ÃƒÂÃ‚ÂµÃƒâ€˜Ã¢â€šÂ¬ÃƒÂÃ‚ÂµÃƒÂÃ‚Â´ÃƒÂÃ‚Â½Ãƒâ€˜Ã‚Â (25$/ÃƒÂÃ‚Â³ÃƒÂÃ‚Â¾ÃƒÂÃ‚Â´)</uk>
+            <ru>ÃƒÂÃ‚Â¡Ãƒâ€˜Ã¢â€šÂ¬ÃƒÂÃ‚ÂµÃƒÂÃ‚Â´ÃƒÂÃ‚Â½Ãƒâ€˜Ã‚ÂÃƒâ€˜Ã‚Â (25$/Ãƒâ€˜Ã¢â‚¬Â¡)</ru>
         
             <da>Mellem ($25/t)</da>
         </text>
@@ -239,16 +239,16 @@
         <text name="wc_diff_3">
             <en>High ($40/h)</en>
             <de>Hoch (40$/h)</de>
-            <fr>Ãƒâ€°levÃƒÂ© (40$/h)</fr>
+            <fr>ÃƒÆ’Ã¢â‚¬Â°levÃƒÆ’Ã‚Â© (40$/h)</fr>
             <pl>Wysoka (40$/h)</pl>
             <es>Alta (40$/h)</es>
             <it>Alta (40$/h)</it>
-            <cz>VysokÃƒÂ¡ (40$/h)</cz>
+            <cz>VysokÃƒÆ’Ã‚Â¡ (40$/h)</cz>
             <br>Alta (40$/h)</br>
-            <uk>Ãâ€™ÃÂ¸Ã‘ÂÃÂ¾ÃÂºÃÂ° (40$/ÃÂ³ÃÂ¾ÃÂ´)</uk>
-            <ru>Ãâ€™Ã‘â€¹Ã‘ÂÃÂ¾ÃÂºÃÂ°Ã‘Â (40$/Ã‘â€¡)</ru>
+            <uk>ÃƒÂÃ¢â‚¬â„¢ÃƒÂÃ‚Â¸Ãƒâ€˜Ã‚ÂÃƒÂÃ‚Â¾ÃƒÂÃ‚ÂºÃƒÂÃ‚Â° (40$/ÃƒÂÃ‚Â³ÃƒÂÃ‚Â¾ÃƒÂÃ‚Â´)</uk>
+            <ru>ÃƒÂÃ¢â‚¬â„¢Ãƒâ€˜Ã¢â‚¬Â¹Ãƒâ€˜Ã‚ÂÃƒÂÃ‚Â¾ÃƒÂÃ‚ÂºÃƒÂÃ‚Â°Ãƒâ€˜Ã‚Â (40$/Ãƒâ€˜Ã¢â‚¬Â¡)</ru>
         
-            <da>HÃƒÂ¸j ($40/t)</da>
+            <da>HÃƒÆ’Ã‚Â¸j ($40/t)</da>
         </text>
         
         <text name="wc_notifications_short">
@@ -258,10 +258,10 @@
             <pl>Powiadomienia</pl>
             <es>Notificaciones</es>
             <it>Notifiche</it>
-            <cz>UpozornÃ„â€ºnÃƒÂ­</cz>
-            <br>NotificaÃƒÂ§ÃƒÂµes</br>
-            <uk>ÃÂ¡ÃÂ¿ÃÂ¾ÃÂ²Ã‘â€“Ã‘â€°ÃÂµÃÂ½ÃÂ½Ã‘Â</uk>
-            <ru>ÃÂ£ÃÂ²ÃÂµÃÂ´ÃÂ¾ÃÂ¼ÃÂ»ÃÂµÃÂ½ÃÂ¸Ã‘Â</ru>
+            <cz>UpozornÃƒâ€žÃ¢â‚¬ÂºnÃƒÆ’Ã‚Â­</cz>
+            <br>NotificaÃƒÆ’Ã‚Â§ÃƒÆ’Ã‚Âµes</br>
+            <uk>ÃƒÂÃ‚Â¡ÃƒÂÃ‚Â¿ÃƒÂÃ‚Â¾ÃƒÂÃ‚Â²Ãƒâ€˜Ã¢â‚¬â€œÃƒâ€˜Ã¢â‚¬Â°ÃƒÂÃ‚ÂµÃƒÂÃ‚Â½ÃƒÂÃ‚Â½Ãƒâ€˜Ã‚Â</uk>
+            <ru>ÃƒÂÃ‚Â£ÃƒÂÃ‚Â²ÃƒÂÃ‚ÂµÃƒÂÃ‚Â´ÃƒÂÃ‚Â¾ÃƒÂÃ‚Â¼ÃƒÂÃ‚Â»ÃƒÂÃ‚ÂµÃƒÂÃ‚Â½ÃƒÂÃ‚Â¸Ãƒâ€˜Ã‚Â</ru>
         
             <da>Notifikationer</da>
         </text>
@@ -269,29 +269,29 @@
         <text name="wc_notifications_long">
             <en>Enable/disable wage payment notifications</en>
             <de>Lohnzahlungsbenachrichtigungen ein-/ausschalten</de>
-            <fr>Activer/dÃƒÂ©sactiver les notifications de paiement des salaires</fr>
-            <pl>WÃ…â€šÃ„â€¦cz/wyÃ…â€šÃ„â€¦cz powiadomienia o wypÃ…â€šatach wynagrodzeÃ…â€ž</pl>
+            <fr>Activer/dÃƒÆ’Ã‚Â©sactiver les notifications de paiement des salaires</fr>
+            <pl>WÃƒâ€¦Ã¢â‚¬Å¡Ãƒâ€žÃ¢â‚¬Â¦cz/wyÃƒâ€¦Ã¢â‚¬Å¡Ãƒâ€žÃ¢â‚¬Â¦cz powiadomienia o wypÃƒâ€¦Ã¢â‚¬Å¡atach wynagrodzeÃƒâ€¦Ã¢â‚¬Å¾</pl>
             <es>Activar/desactivar notificaciones de pago de salarios</es>
             <it>Attiva/disattiva notifiche pagamento salari</it>
-            <cz>Povolit/zakÃƒÂ¡zat upozornÃ„â€ºnÃƒÂ­ na vÃƒÂ½platu mezd</cz>
-            <br>Ativar/desativar notificaÃƒÂ§ÃƒÂµes de pagamento de salÃƒÂ¡rios</br>
-            <uk>ÃÂ£ÃÂ²Ã‘â€“ÃÂ¼ÃÂºÃÂ½Ã‘Æ’Ã‘â€šÃÂ¸/ÃÂ²ÃÂ¸ÃÂ¼ÃÂºÃÂ½Ã‘Æ’Ã‘â€šÃÂ¸ Ã‘ÂÃÂ¿ÃÂ¾ÃÂ²Ã‘â€“Ã‘â€°ÃÂµÃÂ½ÃÂ½Ã‘Â ÃÂ¿Ã‘â‚¬ÃÂ¾ ÃÂ²ÃÂ¸ÃÂ¿ÃÂ»ÃÂ°Ã‘â€šÃ‘Æ’ ÃÂ·ÃÂ°Ã‘â‚¬ÃÂ¾ÃÂ±Ã‘â€“Ã‘â€šÃÂ½ÃÂ¾Ã‘â€” ÃÂ¿ÃÂ»ÃÂ°Ã‘â€šÃÂ¸</uk>
-            <ru>Ãâ€™ÃÂºÃÂ»Ã‘Å½Ã‘â€¡ÃÂ¸Ã‘â€šÃ‘Å’/ÃÂ²Ã‘â€¹ÃÂºÃÂ»Ã‘Å½Ã‘â€¡ÃÂ¸Ã‘â€šÃ‘Å’ Ã‘Æ’ÃÂ²ÃÂµÃÂ´ÃÂ¾ÃÂ¼ÃÂ»ÃÂµÃÂ½ÃÂ¸Ã‘Â ÃÂ¾ ÃÂ²Ã‘â€¹ÃÂ¿ÃÂ»ÃÂ°Ã‘â€šÃÂµ ÃÂ·ÃÂ°Ã‘â‚¬ÃÂ°ÃÂ±ÃÂ¾Ã‘â€šÃÂ½ÃÂ¾ÃÂ¹ ÃÂ¿ÃÂ»ÃÂ°Ã‘â€šÃ‘â€¹</ru>
+            <cz>Povolit/zakÃƒÆ’Ã‚Â¡zat upozornÃƒâ€žÃ¢â‚¬ÂºnÃƒÆ’Ã‚Â­ na vÃƒÆ’Ã‚Â½platu mezd</cz>
+            <br>Ativar/desativar notificaÃƒÆ’Ã‚Â§ÃƒÆ’Ã‚Âµes de pagamento de salÃƒÆ’Ã‚Â¡rios</br>
+            <uk>ÃƒÂÃ‚Â£ÃƒÂÃ‚Â²Ãƒâ€˜Ã¢â‚¬â€œÃƒÂÃ‚Â¼ÃƒÂÃ‚ÂºÃƒÂÃ‚Â½Ãƒâ€˜Ã†â€™Ãƒâ€˜Ã¢â‚¬Å¡ÃƒÂÃ‚Â¸/ÃƒÂÃ‚Â²ÃƒÂÃ‚Â¸ÃƒÂÃ‚Â¼ÃƒÂÃ‚ÂºÃƒÂÃ‚Â½Ãƒâ€˜Ã†â€™Ãƒâ€˜Ã¢â‚¬Å¡ÃƒÂÃ‚Â¸ Ãƒâ€˜Ã‚ÂÃƒÂÃ‚Â¿ÃƒÂÃ‚Â¾ÃƒÂÃ‚Â²Ãƒâ€˜Ã¢â‚¬â€œÃƒâ€˜Ã¢â‚¬Â°ÃƒÂÃ‚ÂµÃƒÂÃ‚Â½ÃƒÂÃ‚Â½Ãƒâ€˜Ã‚Â ÃƒÂÃ‚Â¿Ãƒâ€˜Ã¢â€šÂ¬ÃƒÂÃ‚Â¾ ÃƒÂÃ‚Â²ÃƒÂÃ‚Â¸ÃƒÂÃ‚Â¿ÃƒÂÃ‚Â»ÃƒÂÃ‚Â°Ãƒâ€˜Ã¢â‚¬Å¡Ãƒâ€˜Ã†â€™ ÃƒÂÃ‚Â·ÃƒÂÃ‚Â°Ãƒâ€˜Ã¢â€šÂ¬ÃƒÂÃ‚Â¾ÃƒÂÃ‚Â±Ãƒâ€˜Ã¢â‚¬â€œÃƒâ€˜Ã¢â‚¬Å¡ÃƒÂÃ‚Â½ÃƒÂÃ‚Â¾Ãƒâ€˜Ã¢â‚¬â€ ÃƒÂÃ‚Â¿ÃƒÂÃ‚Â»ÃƒÂÃ‚Â°Ãƒâ€˜Ã¢â‚¬Å¡ÃƒÂÃ‚Â¸</uk>
+            <ru>ÃƒÂÃ¢â‚¬â„¢ÃƒÂÃ‚ÂºÃƒÂÃ‚Â»Ãƒâ€˜Ã…Â½Ãƒâ€˜Ã¢â‚¬Â¡ÃƒÂÃ‚Â¸Ãƒâ€˜Ã¢â‚¬Å¡Ãƒâ€˜Ã…â€™/ÃƒÂÃ‚Â²Ãƒâ€˜Ã¢â‚¬Â¹ÃƒÂÃ‚ÂºÃƒÂÃ‚Â»Ãƒâ€˜Ã…Â½Ãƒâ€˜Ã¢â‚¬Â¡ÃƒÂÃ‚Â¸Ãƒâ€˜Ã¢â‚¬Å¡Ãƒâ€˜Ã…â€™ Ãƒâ€˜Ã†â€™ÃƒÂÃ‚Â²ÃƒÂÃ‚ÂµÃƒÂÃ‚Â´ÃƒÂÃ‚Â¾ÃƒÂÃ‚Â¼ÃƒÂÃ‚Â»ÃƒÂÃ‚ÂµÃƒÂÃ‚Â½ÃƒÂÃ‚Â¸Ãƒâ€˜Ã‚Â ÃƒÂÃ‚Â¾ ÃƒÂÃ‚Â²Ãƒâ€˜Ã¢â‚¬Â¹ÃƒÂÃ‚Â¿ÃƒÂÃ‚Â»ÃƒÂÃ‚Â°Ãƒâ€˜Ã¢â‚¬Å¡ÃƒÂÃ‚Âµ ÃƒÂÃ‚Â·ÃƒÂÃ‚Â°Ãƒâ€˜Ã¢â€šÂ¬ÃƒÂÃ‚Â°ÃƒÂÃ‚Â±ÃƒÂÃ‚Â¾Ãƒâ€˜Ã¢â‚¬Å¡ÃƒÂÃ‚Â½ÃƒÂÃ‚Â¾ÃƒÂÃ‚Â¹ ÃƒÂÃ‚Â¿ÃƒÂÃ‚Â»ÃƒÂÃ‚Â°Ãƒâ€˜Ã¢â‚¬Å¡Ãƒâ€˜Ã¢â‚¬Â¹</ru>
         
-            <da>SlÃƒÂ¥ notifikationer om lÃƒÂ¸nudbetalinger til/fra</da>
+            <da>SlÃƒÆ’Ã‚Â¥ notifikationer om lÃƒÆ’Ã‚Â¸nudbetalinger til/fra</da>
         </text>
         
         <text name="wc_customrate_short">
             <en>Custom Rate</en>
             <de>Benutzerdefinierte Rate</de>
-            <fr>Taux personnalisÃƒÂ©</fr>
+            <fr>Taux personnalisÃƒÆ’Ã‚Â©</fr>
             <pl>Niestandardowa stawka</pl>
             <es>Tasa personalizada</es>
             <it>Tariffa personalizzata</it>
-            <cz>VlastnÃƒÂ­ sazba</cz>
+            <cz>VlastnÃƒÆ’Ã‚Â­ sazba</cz>
             <br>Taxa personalizada</br>
-            <uk>Ãâ€™ÃÂ»ÃÂ°Ã‘ÂÃÂ½ÃÂ° Ã‘ÂÃ‘â€šÃÂ°ÃÂ²ÃÂºÃÂ°</uk>
-            <ru>ÃÅ¸ÃÂ¾ÃÂ»Ã‘Å’ÃÂ·ÃÂ¾ÃÂ²ÃÂ°Ã‘â€šÃÂµÃÂ»Ã‘Å’Ã‘ÂÃÂºÃÂ°Ã‘Â Ã‘ÂÃ‘â€šÃÂ°ÃÂ²ÃÂºÃÂ°</ru>
+            <uk>ÃƒÂÃ¢â‚¬â„¢ÃƒÂÃ‚Â»ÃƒÂÃ‚Â°Ãƒâ€˜Ã‚ÂÃƒÂÃ‚Â½ÃƒÂÃ‚Â° Ãƒâ€˜Ã‚ÂÃƒâ€˜Ã¢â‚¬Å¡ÃƒÂÃ‚Â°ÃƒÂÃ‚Â²ÃƒÂÃ‚ÂºÃƒÂÃ‚Â°</uk>
+            <ru>ÃƒÂÃ…Â¸ÃƒÂÃ‚Â¾ÃƒÂÃ‚Â»Ãƒâ€˜Ã…â€™ÃƒÂÃ‚Â·ÃƒÂÃ‚Â¾ÃƒÂÃ‚Â²ÃƒÂÃ‚Â°Ãƒâ€˜Ã¢â‚¬Å¡ÃƒÂÃ‚ÂµÃƒÂÃ‚Â»Ãƒâ€˜Ã…â€™Ãƒâ€˜Ã‚ÂÃƒÂÃ‚ÂºÃƒÂÃ‚Â°Ãƒâ€˜Ã‚Â Ãƒâ€˜Ã‚ÂÃƒâ€˜Ã¢â‚¬Å¡ÃƒÂÃ‚Â°ÃƒÂÃ‚Â²ÃƒÂÃ‚ÂºÃƒÂÃ‚Â°</ru>
         
             <da>Brugerdefineret sats</da>
         </text>
@@ -299,34 +299,34 @@
         <text name="wc_customrate_long">
             <en>Set custom wage rate (0 = use wage level setting)</en>
             <de>Benutzerdefinierten Lohnsatz festlegen (0 = Lohnniveau verwenden)</de>
-            <fr>DÃƒÂ©finir le taux de salaire personnalisÃƒÂ© (0 = utiliser le niveau de salaire)</fr>
-            <pl>Ustaw niestandardowÃ„â€¦ stawkÃ„â„¢ (0 = uÃ…Â¼yj ustawienia poziomu pÃ…â€šac)</pl>
-            <es>Establecer tasa salarial personalizada (0 = usar configuraciÃƒÂ³n de nivel)</es>
+            <fr>DÃƒÆ’Ã‚Â©finir le taux de salaire personnalisÃƒÆ’Ã‚Â© (0 = utiliser le niveau de salaire)</fr>
+            <pl>Ustaw niestandardowÃƒâ€žÃ¢â‚¬Â¦ stawkÃƒâ€žÃ¢â€žÂ¢ (0 = uÃƒâ€¦Ã‚Â¼yj ustawienia poziomu pÃƒâ€¦Ã¢â‚¬Å¡ac)</pl>
+            <es>Establecer tasa salarial personalizada (0 = usar configuraciÃƒÆ’Ã‚Â³n de nivel)</es>
             <it>Imposta tariffa salariale personalizzata (0 = usa impostazione livello)</it>
-            <cz>Nastavit vlastnÃƒÂ­ mzdovou sazbu (0 = pouÃ…Â¾ÃƒÂ­t nastavenÃƒÂ­ ÃƒÂºrovnÃ„â€º)</cz>
-            <br>Definir taxa salarial personalizada (0 = usar configuraÃƒÂ§ÃƒÂ£o de nÃƒÂ­vel)</br>
-            <uk>Ãâ€™Ã‘ÂÃ‘â€šÃÂ°ÃÂ½ÃÂ¾ÃÂ²ÃÂ¸Ã‘â€šÃÂ¸ ÃÂ²ÃÂ»ÃÂ°Ã‘ÂÃÂ½Ã‘Æ’ Ã‘ÂÃ‘â€šÃÂ°ÃÂ²ÃÂºÃ‘Æ’ ÃÂ¾ÃÂ¿ÃÂ»ÃÂ°Ã‘â€šÃÂ¸ (0 = ÃÂ²ÃÂ¸ÃÂºÃÂ¾Ã‘â‚¬ÃÂ¸Ã‘ÂÃ‘â€šÃÂ¾ÃÂ²Ã‘Æ’ÃÂ²ÃÂ°Ã‘â€šÃÂ¸ ÃÂ½ÃÂ°ÃÂ»ÃÂ°Ã‘Ë†Ã‘â€šÃ‘Æ’ÃÂ²ÃÂ°ÃÂ½ÃÂ½Ã‘Â Ã‘â‚¬Ã‘â€“ÃÂ²ÃÂ½Ã‘Â)</uk>
-            <ru>ÃÂ£Ã‘ÂÃ‘â€šÃÂ°ÃÂ½ÃÂ¾ÃÂ²ÃÂ¸Ã‘â€šÃ‘Å’ ÃÂ¿ÃÂ¾ÃÂ»Ã‘Å’ÃÂ·ÃÂ¾ÃÂ²ÃÂ°Ã‘â€šÃÂµÃÂ»Ã‘Å’Ã‘ÂÃÂºÃ‘Æ’Ã‘Å½ Ã‘ÂÃ‘â€šÃÂ°ÃÂ²ÃÂºÃ‘Æ’ ÃÂ¾ÃÂ¿ÃÂ»ÃÂ°Ã‘â€šÃ‘â€¹ (0 = ÃÂ¸Ã‘ÂÃÂ¿ÃÂ¾ÃÂ»Ã‘Å’ÃÂ·ÃÂ¾ÃÂ²ÃÂ°Ã‘â€šÃ‘Å’ ÃÂ½ÃÂ°Ã‘ÂÃ‘â€šÃ‘â‚¬ÃÂ¾ÃÂ¹ÃÂºÃ‘Æ’ Ã‘Æ’Ã‘â‚¬ÃÂ¾ÃÂ²ÃÂ½Ã‘Â)</ru>
+            <cz>Nastavit vlastnÃƒÆ’Ã‚Â­ mzdovou sazbu (0 = pouÃƒâ€¦Ã‚Â¾ÃƒÆ’Ã‚Â­t nastavenÃƒÆ’Ã‚Â­ ÃƒÆ’Ã‚ÂºrovnÃƒâ€žÃ¢â‚¬Âº)</cz>
+            <br>Definir taxa salarial personalizada (0 = usar configuraÃƒÆ’Ã‚Â§ÃƒÆ’Ã‚Â£o de nÃƒÆ’Ã‚Â­vel)</br>
+            <uk>ÃƒÂÃ¢â‚¬â„¢Ãƒâ€˜Ã‚ÂÃƒâ€˜Ã¢â‚¬Å¡ÃƒÂÃ‚Â°ÃƒÂÃ‚Â½ÃƒÂÃ‚Â¾ÃƒÂÃ‚Â²ÃƒÂÃ‚Â¸Ãƒâ€˜Ã¢â‚¬Å¡ÃƒÂÃ‚Â¸ ÃƒÂÃ‚Â²ÃƒÂÃ‚Â»ÃƒÂÃ‚Â°Ãƒâ€˜Ã‚ÂÃƒÂÃ‚Â½Ãƒâ€˜Ã†â€™ Ãƒâ€˜Ã‚ÂÃƒâ€˜Ã¢â‚¬Å¡ÃƒÂÃ‚Â°ÃƒÂÃ‚Â²ÃƒÂÃ‚ÂºÃƒâ€˜Ã†â€™ ÃƒÂÃ‚Â¾ÃƒÂÃ‚Â¿ÃƒÂÃ‚Â»ÃƒÂÃ‚Â°Ãƒâ€˜Ã¢â‚¬Å¡ÃƒÂÃ‚Â¸ (0 = ÃƒÂÃ‚Â²ÃƒÂÃ‚Â¸ÃƒÂÃ‚ÂºÃƒÂÃ‚Â¾Ãƒâ€˜Ã¢â€šÂ¬ÃƒÂÃ‚Â¸Ãƒâ€˜Ã‚ÂÃƒâ€˜Ã¢â‚¬Å¡ÃƒÂÃ‚Â¾ÃƒÂÃ‚Â²Ãƒâ€˜Ã†â€™ÃƒÂÃ‚Â²ÃƒÂÃ‚Â°Ãƒâ€˜Ã¢â‚¬Å¡ÃƒÂÃ‚Â¸ ÃƒÂÃ‚Â½ÃƒÂÃ‚Â°ÃƒÂÃ‚Â»ÃƒÂÃ‚Â°Ãƒâ€˜Ã‹â€ Ãƒâ€˜Ã¢â‚¬Å¡Ãƒâ€˜Ã†â€™ÃƒÂÃ‚Â²ÃƒÂÃ‚Â°ÃƒÂÃ‚Â½ÃƒÂÃ‚Â½Ãƒâ€˜Ã‚Â Ãƒâ€˜Ã¢â€šÂ¬Ãƒâ€˜Ã¢â‚¬â€œÃƒÂÃ‚Â²ÃƒÂÃ‚Â½Ãƒâ€˜Ã‚Â)</uk>
+            <ru>ÃƒÂÃ‚Â£Ãƒâ€˜Ã‚ÂÃƒâ€˜Ã¢â‚¬Å¡ÃƒÂÃ‚Â°ÃƒÂÃ‚Â½ÃƒÂÃ‚Â¾ÃƒÂÃ‚Â²ÃƒÂÃ‚Â¸Ãƒâ€˜Ã¢â‚¬Å¡Ãƒâ€˜Ã…â€™ ÃƒÂÃ‚Â¿ÃƒÂÃ‚Â¾ÃƒÂÃ‚Â»Ãƒâ€˜Ã…â€™ÃƒÂÃ‚Â·ÃƒÂÃ‚Â¾ÃƒÂÃ‚Â²ÃƒÂÃ‚Â°Ãƒâ€˜Ã¢â‚¬Å¡ÃƒÂÃ‚ÂµÃƒÂÃ‚Â»Ãƒâ€˜Ã…â€™Ãƒâ€˜Ã‚ÂÃƒÂÃ‚ÂºÃƒâ€˜Ã†â€™Ãƒâ€˜Ã…Â½ Ãƒâ€˜Ã‚ÂÃƒâ€˜Ã¢â‚¬Å¡ÃƒÂÃ‚Â°ÃƒÂÃ‚Â²ÃƒÂÃ‚ÂºÃƒâ€˜Ã†â€™ ÃƒÂÃ‚Â¾ÃƒÂÃ‚Â¿ÃƒÂÃ‚Â»ÃƒÂÃ‚Â°Ãƒâ€˜Ã¢â‚¬Å¡Ãƒâ€˜Ã¢â‚¬Â¹ (0 = ÃƒÂÃ‚Â¸Ãƒâ€˜Ã‚ÂÃƒÂÃ‚Â¿ÃƒÂÃ‚Â¾ÃƒÂÃ‚Â»Ãƒâ€˜Ã…â€™ÃƒÂÃ‚Â·ÃƒÂÃ‚Â¾ÃƒÂÃ‚Â²ÃƒÂÃ‚Â°Ãƒâ€˜Ã¢â‚¬Å¡Ãƒâ€˜Ã…â€™ ÃƒÂÃ‚Â½ÃƒÂÃ‚Â°Ãƒâ€˜Ã‚ÂÃƒâ€˜Ã¢â‚¬Å¡Ãƒâ€˜Ã¢â€šÂ¬ÃƒÂÃ‚Â¾ÃƒÂÃ‚Â¹ÃƒÂÃ‚ÂºÃƒâ€˜Ã†â€™ Ãƒâ€˜Ã†â€™Ãƒâ€˜Ã¢â€šÂ¬ÃƒÂÃ‚Â¾ÃƒÂÃ‚Â²ÃƒÂÃ‚Â½Ãƒâ€˜Ã‚Â)</ru>
         
-            <da>Angiv brugerdefineret lÃƒÂ¸nsats (0 = brug lÃƒÂ¸nniveau-indstillingen)</da>
+            <da>Angiv brugerdefineret lÃƒÆ’Ã‚Â¸nsats (0 = brug lÃƒÆ’Ã‚Â¸nniveau-indstillingen)</da>
         </text>
         
         <text name="wc_reset">
             <en>Reset Worker Settings</en>
-            <de>Arbeitereinstellungen zurÃƒÂ¼cksetzen</de>
-            <fr>RÃƒÂ©initialiser les paramÃƒÂ¨tres des ouvriers</fr>
-            <pl>Resetuj ustawienia pracownikÃƒÂ³w</pl>
+            <de>Arbeitereinstellungen zurÃƒÆ’Ã‚Â¼cksetzen</de>
+            <fr>RÃƒÆ’Ã‚Â©initialiser les paramÃƒÆ’Ã‚Â¨tres des ouvriers</fr>
+            <pl>Resetuj ustawienia pracownikÃƒÆ’Ã‚Â³w</pl>
             <es>Restablecer config. trabajadores</es>
             <it>Ripristina impostazioni operai</it>
-            <cz>Resetovat nastavenÃƒÂ­ pracovnÃƒÂ­kÃ…Â¯</cz>
-            <br>Restaurar configuraÃƒÂ§ÃƒÂµes de trabalhadores</br>
-            <uk>ÃÂ¡ÃÂºÃÂ¸ÃÂ½Ã‘Æ’Ã‘â€šÃÂ¸ ÃÂ½ÃÂ°ÃÂ»ÃÂ°Ã‘Ë†Ã‘â€šÃ‘Æ’ÃÂ²ÃÂ°ÃÂ½ÃÂ½Ã‘Â ÃÂ¿Ã‘â‚¬ÃÂ°Ã‘â€ Ã‘â€“ÃÂ²ÃÂ½ÃÂ¸ÃÂºÃ‘â€“ÃÂ²</uk>
-            <ru>ÃÂ¡ÃÂ±Ã‘â‚¬ÃÂ¾Ã‘ÂÃÂ¸Ã‘â€šÃ‘Å’ ÃÂ½ÃÂ°Ã‘ÂÃ‘â€šÃ‘â‚¬ÃÂ¾ÃÂ¹ÃÂºÃÂ¸ Ã‘â‚¬ÃÂ°ÃÂ±ÃÂ¾Ã‘â€šÃÂ½ÃÂ¸ÃÂºÃÂ¾ÃÂ²</ru>
+            <cz>Resetovat nastavenÃƒÆ’Ã‚Â­ pracovnÃƒÆ’Ã‚Â­kÃƒâ€¦Ã‚Â¯</cz>
+            <br>Restaurar configuraÃƒÆ’Ã‚Â§ÃƒÆ’Ã‚Âµes de trabalhadores</br>
+            <uk>ÃƒÂÃ‚Â¡ÃƒÂÃ‚ÂºÃƒÂÃ‚Â¸ÃƒÂÃ‚Â½Ãƒâ€˜Ã†â€™Ãƒâ€˜Ã¢â‚¬Å¡ÃƒÂÃ‚Â¸ ÃƒÂÃ‚Â½ÃƒÂÃ‚Â°ÃƒÂÃ‚Â»ÃƒÂÃ‚Â°Ãƒâ€˜Ã‹â€ Ãƒâ€˜Ã¢â‚¬Å¡Ãƒâ€˜Ã†â€™ÃƒÂÃ‚Â²ÃƒÂÃ‚Â°ÃƒÂÃ‚Â½ÃƒÂÃ‚Â½Ãƒâ€˜Ã‚Â ÃƒÂÃ‚Â¿Ãƒâ€˜Ã¢â€šÂ¬ÃƒÂÃ‚Â°Ãƒâ€˜Ã¢â‚¬Â Ãƒâ€˜Ã¢â‚¬â€œÃƒÂÃ‚Â²ÃƒÂÃ‚Â½ÃƒÂÃ‚Â¸ÃƒÂÃ‚ÂºÃƒâ€˜Ã¢â‚¬â€œÃƒÂÃ‚Â²</uk>
+            <ru>ÃƒÂÃ‚Â¡ÃƒÂÃ‚Â±Ãƒâ€˜Ã¢â€šÂ¬ÃƒÂÃ‚Â¾Ãƒâ€˜Ã‚ÂÃƒÂÃ‚Â¸Ãƒâ€˜Ã¢â‚¬Å¡Ãƒâ€˜Ã…â€™ ÃƒÂÃ‚Â½ÃƒÂÃ‚Â°Ãƒâ€˜Ã‚ÂÃƒâ€˜Ã¢â‚¬Å¡Ãƒâ€˜Ã¢â€šÂ¬ÃƒÂÃ‚Â¾ÃƒÂÃ‚Â¹ÃƒÂÃ‚ÂºÃƒÂÃ‚Â¸ Ãƒâ€˜Ã¢â€šÂ¬ÃƒÂÃ‚Â°ÃƒÂÃ‚Â±ÃƒÂÃ‚Â¾Ãƒâ€˜Ã¢â‚¬Å¡ÃƒÂÃ‚Â½ÃƒÂÃ‚Â¸ÃƒÂÃ‚ÂºÃƒÂÃ‚Â¾ÃƒÂÃ‚Â²</ru>
         
             <da>Nulstil medarbejderindstillinger</da>
         </text>
 
-        <!-- Ã¢â€¢ÂÃ¢â€¢ÂÃ¢â€¢ÂÃ¢â€¢Â New Pause Menu GUI strings Ã¢â€¢ÂÃ¢â€¢ÂÃ¢â€¢ÂÃ¢â€¢Â -->
+        <!-- ÃƒÂ¢Ã¢â‚¬Â¢Ã‚ÂÃƒÂ¢Ã¢â‚¬Â¢Ã‚ÂÃƒÂ¢Ã¢â‚¬Â¢Ã‚ÂÃƒÂ¢Ã¢â‚¬Â¢Ã‚Â New Pause Menu GUI strings ÃƒÂ¢Ã¢â‚¬Â¢Ã‚ÂÃƒÂ¢Ã¢â‚¬Â¢Ã‚ÂÃƒÂ¢Ã¢â‚¬Â¢Ã‚ÂÃƒÂ¢Ã¢â‚¬Â¢Ã‚Â -->
 
         <text name="wc_menu_title">
             <en>Worker Costs</en>
@@ -368,7 +368,7 @@
             <br>[EN] Open Manager</br>
             <uk>[EN] Open Manager</uk>
             <ru>[EN] Open Manager</ru>
-            <da>Ãƒâ€¦bn manager</da>
+            <da>ÃƒÆ’Ã¢â‚¬Â¦bn manager</da>
         </text>
         <text name="wc_hint_open_manager">
             <en>Press Accept to open the full Worker Costs manager.</en>
@@ -382,13 +382,13 @@
             <br>[EN] Press Accept to open the full Worker Costs manager.</br>
             <uk>[EN] Press Accept to open the full Worker Costs manager.</uk>
             <ru>[EN] Press Accept to open the full Worker Costs manager.</ru>
-            <da>Tryk pÃƒÂ¥ AcceptÃƒÂ©r for at ÃƒÂ¥bne den fulde styring</da>
+            <da>Tryk pÃƒÆ’Ã‚Â¥ AcceptÃƒÆ’Ã‚Â©r for at ÃƒÆ’Ã‚Â¥bne den fulde styring</da>
         </text>
 
         <!-- Tab titles -->
         <text name="wc_tab_dashboard">
             <en>Dashboard</en>
-            <de>ÃƒÅ“bersicht</de>
+            <de>ÃƒÆ’Ã…â€œbersicht</de>
             <fr>Tableau de bord</fr>
             <pl>Panel</pl>
             <es>Panel</es>
@@ -403,16 +403,16 @@
         <text name="wc_tab_wage_settings">
             <en>Wage Settings</en>
             <de>Lohneinstellungen</de>
-            <fr>ParamÃƒÂ¨tres Salaire</fr>
-            <pl>Ustawienia pÃ…â€šac</pl>
-            <es>ConfiguraciÃƒÂ³n salarial</es>
+            <fr>ParamÃƒÆ’Ã‚Â¨tres Salaire</fr>
+            <pl>Ustawienia pÃƒâ€¦Ã¢â‚¬Å¡ac</pl>
+            <es>ConfiguraciÃƒÆ’Ã‚Â³n salarial</es>
         
             <it>[EN] Wage Settings</it>
             <cz>[EN] Wage Settings</cz>
             <br>[EN] Wage Settings</br>
             <uk>[EN] Wage Settings</uk>
             <ru>[EN] Wage Settings</ru>
-            <da>LÃƒÂ¸n indstillinger</da>
+            <da>LÃƒÆ’Ã‚Â¸n indstillinger</da>
         </text>
         
         <!-- Section headings -->
@@ -598,7 +598,7 @@
             <br>[EN] Next Payment:</br>
             <uk>[EN] Next Payment:</uk>
             <ru>[EN] Next Payment:</ru>
-            <da>NÃƒÂ¦ste lÃƒÂ¸nudbetaling:</da>
+            <da>NÃƒÆ’Ã‚Â¦ste lÃƒÆ’Ã‚Â¸nudbetaling:</da>
         </text>
         <text name="wc_label_est_cost">
             <en>Est. Cost:</en>
@@ -626,7 +626,7 @@
             <br>[EN] Farm Balance:</br>
             <uk>[EN] Farm Balance:</uk>
             <ru>[EN] Farm Balance:</ru>
-            <da>GÃƒÂ¥rdsaldo:</da>
+            <da>GÃƒÆ’Ã‚Â¥rdsaldo:</da>
         </text>
         <text name="wc_label_worker_list">
             <en>Worker Names</en>
@@ -704,7 +704,7 @@
             <en>No active workers</en>
             <de>Keine aktiven Arbeiter</de>
             <fr>Aucun ouvrier actif</fr>
-            <pl>Brak aktywnych pracownikÃƒÂ³w</pl>
+            <pl>Brak aktywnych pracownikÃƒÆ’Ã‚Â³w</pl>
             <es>Sin trabajadores activos</es>
         
             <it>[EN] No active workers</it>
@@ -720,7 +720,7 @@
             <en>Configuration</en>
             <de>Konfiguration</de>
             <fr>Configuration</fr>
-            <es>ConfiguraciÃƒÂ³n</es>
+            <es>ConfiguraciÃƒÆ’Ã‚Â³n</es>
         
             <pl>[EN] Configuration</pl>
             <it>[EN] Configuration</it>
@@ -733,7 +733,7 @@
         <text name="wc_section_summary">
             <en>Summary</en>
             <de>Zusammenfassung</de>
-            <fr>RÃƒÂ©sumÃƒÂ©</fr>
+            <fr>RÃƒÆ’Ã‚Â©sumÃƒÆ’Ã‚Â©</fr>
             <es>Resumen</es>
         
             <pl>[EN] Summary</pl>
@@ -746,8 +746,8 @@
         </text>
         <text name="wc_section_breakdown">
             <en>Labor Cost Breakdown</en>
-            <de>Arbeiter-AufschlÃƒÂ¼sselung</de>
-            <fr>DÃƒÂ©tail par ouvrier</fr>
+            <de>Arbeiter-AufschlÃƒÆ’Ã‚Â¼sselung</de>
+            <fr>DÃƒÆ’Ã‚Â©tail par ouvrier</fr>
             <es>Desglose de trabajadores</es>
 
             <pl>[EN] Labor Cost Breakdown</pl>
@@ -761,8 +761,8 @@
         <text name="wc_section_how_it_works">
             <en>How It Works</en>
             <de>Funktionsweise</de>
-            <fr>Comment ÃƒÂ§a marche</fr>
-            <es>CÃƒÂ³mo funciona</es>
+            <fr>Comment ÃƒÆ’Ã‚Â§a marche</fr>
+            <es>CÃƒÆ’Ã‚Â³mo funciona</es>
         
             <pl>[EN] How It Works</pl>
             <it>[EN] How It Works</it>
@@ -791,7 +791,7 @@
         <text name="wc_col_interval_cost">
             <en>COST / INTERVAL</en>
             <de>KOSTEN / INTERVALL</de>
-            <fr>COÃƒâ€ºT / INTERVALLE</fr>
+            <fr>COÃƒÆ’Ã¢â‚¬ÂºT / INTERVALLE</fr>
             <es>COSTO / INTERVALO</es>
         
             <pl>[EN] COST / INTERVAL</pl>
@@ -851,7 +851,7 @@
         <text name="wc_tab_about">
             <en>About</en>
             <de>Info</de>
-            <fr>Ãƒâ‚¬ propos</fr>
+            <fr>ÃƒÆ’Ã¢â€šÂ¬ propos</fr>
             <es>Acerca de</es>
         
             <pl>[EN] About</pl>
@@ -1108,7 +1108,7 @@
             <en>VERSION</en>
             <de>VERSION</de>
             <fr>VERSION</fr>
-            <es>VERSIÃƒâ€œN</es>
+            <es>VERSIÃƒÆ’Ã¢â‚¬Å“N</es>
         
             <pl>[EN] VERSION</pl>
             <it>[EN] VERSION</it>
@@ -1120,9 +1120,9 @@
         </text>
         <text name="wc_about_payment_note">
             <en>Payments follow the in-game calendar. Wages accrue while workers are active and are deducted silently once per in-game day at midnight.</en>
-            <de>Zahlungen folgen dem Spielkalender. LÃƒÂ¶hne laufen auf, wÃƒÂ¤hrend Arbeiter aktiv sind, und werden einmal pro Spieltag um Mitternacht abgezogen.</de>
-            <fr>Les paiements suivent le calendrier du jeu. Les salaires s'accumulent pendant que les ouvriers travaillent et sont dÃƒÂ©duits une fois par jour de jeu, ÃƒÂ  minuit.</fr>
-            <es>Los pagos siguen el calendario del juego. Los salarios se acumulan mientras los trabajadores estÃƒÂ¡n activos y se deducen una vez por dÃƒÂ­a de juego, a medianoche.</es>
+            <de>Zahlungen folgen dem Spielkalender. LÃƒÆ’Ã‚Â¶hne laufen auf, wÃƒÆ’Ã‚Â¤hrend Arbeiter aktiv sind, und werden einmal pro Spieltag um Mitternacht abgezogen.</de>
+            <fr>Les paiements suivent le calendrier du jeu. Les salaires s'accumulent pendant que les ouvriers travaillent et sont dÃƒÆ’Ã‚Â©duits une fois par jour de jeu, ÃƒÆ’Ã‚Â  minuit.</fr>
+            <es>Los pagos siguen el calendario del juego. Los salarios se acumulan mientras los trabajadores estÃƒÆ’Ã‚Â¡n activos y se deducen una vez por dÃƒÆ’Ã‚Â­a de juego, a medianoche.</es>
         
             <pl>[EN] Payments follow the in-game calendar. Wages accrue while workers are active and are deducted once per in-game day at midnight.</pl>
             <it>[EN] Payments follow the in-game calendar. Wages accrue while workers are active and are deducted once per in-game day at midnight.</it>
@@ -1130,7 +1130,7 @@
             <br>[EN] Payments follow the in-game calendar. Wages accrue while workers are active and are deducted once per in-game day at midnight.</br>
             <uk>[EN] Payments follow the in-game calendar. Wages accrue while workers are active and are deducted once per in-game day at midnight.</uk>
             <ru>[EN] Payments follow the in-game calendar. Wages accrue while workers are active and are deducted once per in-game day at midnight.</ru>
-            <da>Betalinger fÃƒÂ¸lger spillets kalender. LÃƒÂ¸nnen optjenes, mens medarbejderne er aktive, og trÃƒÂ¦kkes automatisk en gang pr. spildag ved midnat.</da>
+            <da>Betalinger fÃƒÆ’Ã‚Â¸lger spillets kalender. LÃƒÆ’Ã‚Â¸nnen optjenes, mens medarbejderne er aktive, og trÃƒÆ’Ã‚Â¦kkes automatisk en gang pr. spildag ved midnat.</da>
         </text>
         <text name="wc_about_body">
             <en>Realistic Worker Costs replaces the default worker pay system with a billing model based on real time.
@@ -1151,8 +1151,8 @@ The Worker Stats tab shows a live breakdown of costs per worker for the current 
 
 This mod is multiplayer compatible. Settings are saved per save game.</en>
             <de>Realistische Arbeiterkosten ersetzt das Standard-Arbeiterlohnsystem durch ein Abrechnungsmodell auf Basis von Echtzeit.</de>
-            <fr>CoÃƒÂ»ts RÃƒÂ©alistes des Ouvriers remplace le systÃƒÂ¨me de salaire par dÃƒÂ©faut par un modÃƒÂ¨le de facturation basÃƒÂ© sur le temps rÃƒÂ©el.</fr>
-            <es>Costos Realistas de Trabajadores reemplaza el sistema de pago de trabajadores predeterminado con un modelo de facturaciÃƒÂ³n basado en tiempo real.</es>
+            <fr>CoÃƒÆ’Ã‚Â»ts RÃƒÆ’Ã‚Â©alistes des Ouvriers remplace le systÃƒÆ’Ã‚Â¨me de salaire par dÃƒÆ’Ã‚Â©faut par un modÃƒÆ’Ã‚Â¨le de facturation basÃƒÆ’Ã‚Â© sur le temps rÃƒÆ’Ã‚Â©el.</fr>
+            <es>Costos Realistas de Trabajadores reemplaza el sistema de pago de trabajadores predeterminado con un modelo de facturaciÃƒÆ’Ã‚Â³n basado en tiempo real.</es>
         
             <pl>[EN] Realistic Worker Costs replaces the default worker pay system with a billing model based on real time.
 
@@ -1256,18 +1256,18 @@ WORKER STATS
 The Worker Stats tab shows a live breakdown of costs per worker for the current billing interval.
 
 This mod is multiplayer compatible. Settings are saved per save game.</ru>
-            <da>Realistic Worker Costs erstatter standardlÃƒÂ¸nssystemet for medarbejdere med en faktureringsmodel baseret pÃƒÂ¥ realtid.
+            <da>Realistic Worker Costs erstatter standardlÃƒÆ’Ã‚Â¸nssystemet for medarbejdere med en faktureringsmodel baseret pÃƒÆ’Ã‚Â¥ realtid.
 
-Medarbejdere opkrÃƒÂ¦ves efter en fast tidsplan uanset spillets hastighed. Hver aktiv AI-medarbejder koster penge ved hvert betalingsinterval.
+Medarbejdere opkrÃƒÆ’Ã‚Â¦ves efter en fast tidsplan uanset spillets hastighed. Hver aktiv AI-medarbejder koster penge ved hvert betalingsinterval.
 
 TIMEBASERET TILSTAND
-En fast sats pr. medarbejder pr. time. Omkostningerne skalerer efter, hvor mange medarbejdere der er aktive, og hvor lÃƒÂ¦nge de arbejder.
+En fast sats pr. medarbejder pr. time. Omkostningerne skalerer efter, hvor mange medarbejdere der er aktive, og hvor lÃƒÆ’Ã‚Â¦nge de arbejder.
 
 PR. HEKTAR-TILSTAND
-Medarbejdere opkrÃƒÂ¦ves baseret pÃƒÂ¥ det bearbejdede areal. Satsen pr. hektar skalerer med din indstilling for lÃƒÂ¸nniveau.
+Medarbejdere opkrÃƒÆ’Ã‚Â¦ves baseret pÃƒÆ’Ã‚Â¥ det bearbejdede areal. Satsen pr. hektar skalerer med din indstilling for lÃƒÆ’Ã‚Â¸nniveau.
 
-LÃƒËœNINDSTILLINGER
-Juster omkostningstilstand, lÃƒÂ¸nniveau, og slÃƒÂ¥ notifikationer til eller fra i fanen LÃƒÂ¸nindstillinger. Brug Nulstil for at gendanne standardindstillingerne.
+LÃƒÆ’Ã‹Å“NINDSTILLINGER
+Juster omkostningstilstand, lÃƒÆ’Ã‚Â¸nniveau, og slÃƒÆ’Ã‚Â¥ notifikationer til eller fra i fanen LÃƒÆ’Ã‚Â¸nindstillinger. Brug Nulstil for at gendanne standardindstillingerne.
 
 MEDARBEJDERSTATISTIK
 Fanen Medarbejderstatistik viser en live oversigt over omkostninger pr. medarbejder for det aktuelle betalingsinterval.
@@ -1278,9 +1278,9 @@ Denne mod er kompatibel med multiplayer. Indstillinger gemmes pr. savegame.</da>
         <!-- WCMenuPage landing -->
         <text name="wc_menu_description">
             <en>Monitor your worker costs and billing status at a glance. Open the Worker Manager for live stats, detailed breakdowns, and full settings control.</en>
-            <de>ÃƒÅ“berwachen Sie Ihre Arbeitskosten und den Abrechnungsstatus auf einen Blick.</de>
-            <fr>Surveillez vos coÃƒÂ»ts de main-d'oeuvre d'un coup d'oeil. Ouvrez le Gestionnaire pour les statistiques en direct.</fr>
-            <es>Supervise los costos de sus trabajadores de un vistazo. Abra el Administrador para estadÃƒÂ­sticas en vivo.</es>
+            <de>ÃƒÆ’Ã…â€œberwachen Sie Ihre Arbeitskosten und den Abrechnungsstatus auf einen Blick.</de>
+            <fr>Surveillez vos coÃƒÆ’Ã‚Â»ts de main-d'oeuvre d'un coup d'oeil. Ouvrez le Gestionnaire pour les statistiques en direct.</fr>
+            <es>Supervise los costos de sus trabajadores de un vistazo. Abra el Administrador para estadÃƒÆ’Ã‚Â­sticas en vivo.</es>
         
             <pl>[EN] Monitor your worker costs and billing status at a glance. Open the Worker Manager for live stats, detailed breakdowns, and full settings control.</pl>
             <it>[EN] Monitor your worker costs and billing status at a glance. Open the Worker Manager for live stats, detailed breakdowns, and full settings control.</it>
@@ -1288,7 +1288,7 @@ Denne mod er kompatibel med multiplayer. Indstillinger gemmes pr. savegame.</da>
             <br>[EN] Monitor your worker costs and billing status at a glance. Open the Worker Manager for live stats, detailed breakdowns, and full settings control.</br>
             <uk>[EN] Monitor your worker costs and billing status at a glance. Open the Worker Manager for live stats, detailed breakdowns, and full settings control.</uk>
             <ru>[EN] Monitor your worker costs and billing status at a glance. Open the Worker Manager for live stats, detailed breakdowns, and full settings control.</ru>
-            <da>FÃƒÂ¥ et hurtigt overblik over dine medarbejderomkostninger og betalingsstatus. Ãƒâ€¦bn medarbejderstyringen for live statistik, detaljerede oversigter og fuld kontrol over indstillingerne</da>
+            <da>FÃƒÆ’Ã‚Â¥ et hurtigt overblik over dine medarbejderomkostninger og betalingsstatus. ÃƒÆ’Ã¢â‚¬Â¦bn medarbejderstyringen for live statistik, detaljerede oversigter og fuld kontrol over indstillingerne</da>
         </text>
 
         <!-- Help text for Wage Settings tab -->
@@ -1440,17 +1440,17 @@ Settled once per in-game day at midnight, based on the in-game time worked.
 Use Reset to restore all settings to their defaults.</ru>
             <da>BETALINGSSTRATEGI
 Timebaseret - betal en fast sats pr. medarbejder pr. arbejdstime.
-Pr. hektar - betal baseret pÃƒÂ¥ det bearbejdede areal.
+Pr. hektar - betal baseret pÃƒÆ’Ã‚Â¥ det bearbejdede areal.
 
 KOMPENSATIONSNIVEAU
 Lav = $15 pr. medarbejder pr. time
 Mellem = $25 pr. medarbejder pr. time
-HÃƒÂ¸j = $40 pr. medarbejder pr. time
+HÃƒÆ’Ã‚Â¸j = $40 pr. medarbejder pr. time
 
 BETALINGER
-Afregnes en gang pr. spildag ved midnat, baseret pÃƒÂ¥ den arbejdede tid i spillet.
+Afregnes en gang pr. spildag ved midnat, baseret pÃƒÆ’Ã‚Â¥ den arbejdede tid i spillet.
 
-Brug Nulstil for at gendanne alle indstillinger til standardvÃƒÂ¦rdierne.</da>
+Brug Nulstil for at gendanne alle indstillinger til standardvÃƒÆ’Ã‚Â¦rdierne.</da>
         </text>
         <text name="wc_help_body_ha">
             <en>PAYMENT STRATEGY
@@ -1575,17 +1575,17 @@ Settled once per in-game day at midnight, based on area worked. Workers not curr
 
 Use Reset to restore all settings to their defaults.</ru>
             <da>BETALINGSSTRATEGI
-Pr. hektar - medarbejdere opkrÃƒÂ¦ves pr. hektar bearbejdet mark siden sidste afregning.
+Pr. hektar - medarbejdere opkrÃƒÆ’Ã‚Â¦ves pr. hektar bearbejdet mark siden sidste afregning.
 
 KOMPENSATIONSNIVEAU (pr. hektar)
 Lav = $15 pr. hektar bearbejdet
 Mellem = $25 pr. hektar bearbejdet
-HÃƒÂ¸j = $40 pr. hektar bearbejdet
+HÃƒÆ’Ã‚Â¸j = $40 pr. hektar bearbejdet
 
 BETALINGER
-Afregnes en gang pr. spildag ved midnat, baseret pÃƒÂ¥ det bearbejdede areal. Medarbejdere, der ikke er aktive, opkrÃƒÂ¦ves ikke for den pÃƒÂ¥gÃƒÂ¦ldende dag.
+Afregnes en gang pr. spildag ved midnat, baseret pÃƒÆ’Ã‚Â¥ det bearbejdede areal. Medarbejdere, der ikke er aktive, opkrÃƒÆ’Ã‚Â¦ves ikke for den pÃƒÆ’Ã‚Â¥gÃƒÆ’Ã‚Â¦ldende dag.
 
-Brug Nulstil for at gendanne alle indstillinger til standardvÃƒÂ¦rdierne.</da>
+Brug Nulstil for at gendanne alle indstillinger til standardvÃƒÆ’Ã‚Â¦rdierne.</da>
         </text>
         <text name="rf_pda_col_area">
             <br>[EN] Area</br>
@@ -1693,59 +1693,59 @@ Brug Nulstil for at gendanne alle indstillinger til standardvÃƒÂ¦rdierne.</d
         </text>
                 <text name="wc_rf_pda_open_manager">
             <br>Abrir gerenciador de trabalhadores</br>
-            <cz>Otevřít správce pracovníků</cz>
-            <da>Åbn medarbejderstyring</da>
-            <de>Arbeitermanager öffnen</de>
+            <cz>OtevÅ™Ã­t sprÃ¡vce pracovnÃ­kÅ¯</cz>
+            <da>Ã…bn medarbejderstyring</da>
+            <de>Arbeitermanager Ã¶ffnen</de>
             <en>Open Worker Manager</en>
             <es>Abrir gestor de trabajadores</es>
             <fr>Ouvrir le gestionnaire d'ouvriers</fr>
             <it>Apri gestore operai</it>
-            <pl>Otwórz menedżera pracowników</pl>
-            <ru>Открыть менеджер работников</ru>
-            <uk>Відкрити менеджер працівників</uk>
+            <pl>OtwÃ³rz menedÅ¼era pracownikÃ³w</pl>
+            <ru>ÐžÑ‚ÐºÑ€Ñ‹Ñ‚ÑŒ Ð¼ÐµÐ½ÐµÐ´Ð¶ÐµÑ€ Ñ€Ð°Ð±Ð¾Ñ‚Ð½Ð¸ÐºÐ¾Ð²</ru>
+            <uk>Ð’Ñ–Ð´ÐºÑ€Ð¸Ñ‚Ð¸ Ð¼ÐµÐ½ÐµÐ´Ð¶ÐµÑ€ Ð¿Ñ€Ð°Ñ†Ñ–Ð²Ð½Ð¸ÐºÑ–Ð²</uk>
             <nl>Werkersbeheer openen</nl>
             <pt>Abrir gestor de trabalhadores</pt>
-            <sv>Öppna arbetshanteraren</sv>
-            <no>Åpne arbeiderbehandler</no>
-            <fi>Avaa työntekijähallinta</fi>
-            <hu>Dolgozókezelő megnyitása</hu>
+            <sv>Ã–ppna arbetshanteraren</sv>
+            <no>Ã…pne arbeiderbehandler</no>
+            <fi>Avaa tyÃ¶ntekijÃ¤hallinta</fi>
+            <hu>DolgozÃ³kezelÅ‘ megnyitÃ¡sa</hu>
             <ro>Deschide managerul de muncitori</ro>
-            <tr>İşçi yöneticisini aç</tr>
-            <jp>作業員マネージャーを開く</jp>
-            <kr>작업자 관리자 열기</kr>
-            <ct>開啟工人管理員</ct>
+            <tr>Ä°ÅŸÃ§i yÃ¶neticisini aÃ§</tr>
+            <jp>ä½œæ¥­å“¡ãƒžãƒãƒ¼ã‚¸ãƒ£ãƒ¼ã‚’é–‹ã</jp>
+            <kr>ìž‘ì—…ìž ê´€ë¦¬ìž ì—´ê¸°</kr>
+            <ct>é–‹å•Ÿå·¥äººç®¡ç†å“¡</ct>
             <fc>Ouvrir le gestionnaire d'ouvriers</fc>
             <ea>Abrir gestor de trabajadores</ea>
             <id>Buka manajer pekerja</id>
-            <vi>Mở trình quản lý công nhân</vi>
+            <vi>Má»Ÿ trÃ¬nh quáº£n lÃ½ cÃ´ng nhÃ¢n</vi>
         </text>
         <text name="sf_pda_btn_rotation_planner">
-            <br>Planejador de rotação</br>
-            <cz>Plánovač osevního postupu</cz>
-            <da>Rotationsplanlægger</da>
+            <br>Planejador de rotaÃ§Ã£o</br>
+            <cz>PlÃ¡novaÄ osevnÃ­ho postupu</cz>
+            <da>RotationsplanlÃ¦gger</da>
             <de>Fruchtfolgeplaner</de>
             <en>Rotation Planner</en>
-            <es>Planificador de rotación</es>
+            <es>Planificador de rotaciÃ³n</es>
             <fr>Planificateur de rotation</fr>
             <it>Pianificatore rotazioni</it>
-            <pl>Planer płodozmianu</pl>
-            <ru>Планировщик севооборота</ru>
-            <uk>Планувальник сівозміни</uk>
+            <pl>Planer pÅ‚odozmianu</pl>
+            <ru>ÐŸÐ»Ð°Ð½Ð¸Ñ€Ð¾Ð²Ñ‰Ð¸Ðº ÑÐµÐ²Ð¾Ð¾Ð±Ð¾Ñ€Ð¾Ñ‚Ð°</ru>
+            <uk>ÐŸÐ»Ð°Ð½ÑƒÐ²Ð°Ð»ÑŒÐ½Ð¸Ðº ÑÑ–Ð²Ð¾Ð·Ð¼Ñ–Ð½Ð¸</uk>
             <nl>Rotatieplanner</nl>
-            <pt>Planeador de rotação</pt>
-            <sv>Växtföljdsplanerare</sv>
+            <pt>Planeador de rotaÃ§Ã£o</pt>
+            <sv>VÃ¤xtfÃ¶ljdsplanerare</sv>
             <no>Rotasjonsplanlegger</no>
             <fi>Viljelykiertosuunnittelija</fi>
-            <hu>Vetésforgó-tervező</hu>
-            <ro>Planificator de rotație</ro>
-            <tr>Ekim nöbeti planlayıcı</tr>
-            <jp>輪作プランナー</jp>
-            <kr>윤작 계획기</kr>
-            <ct>輪作規劃</ct>
+            <hu>VetÃ©sforgÃ³-tervezÅ‘</hu>
+            <ro>Planificator de rotaÈ›ie</ro>
+            <tr>Ekim nÃ¶beti planlayÄ±cÄ±</tr>
+            <jp>è¼ªä½œãƒ—ãƒ©ãƒ³ãƒŠãƒ¼</jp>
+            <kr>ìœ¤ìž‘ ê³„íšê¸°</kr>
+            <ct>è¼ªä½œè¦åŠƒ</ct>
             <fc>Planificateur de rotation</fc>
-            <ea>Planificador de rotación</ea>
+            <ea>Planificador de rotaciÃ³n</ea>
             <id>Perencana rotasi</id>
-            <vi>Lập kế hoạch luân canh</vi>
+            <vi>Láº­p káº¿ hoáº¡ch luÃ¢n canh</vi>
         </text>
         <text name="sf_pda_btn_field_detail">
             <br>Detalhe do campo</br>
@@ -1754,26 +1754,26 @@ Brug Nulstil for at gendanne alle indstillinger til standardvÃƒÂ¦rdierne.</d
             <de>Felddetails</de>
             <en>Field Detail</en>
             <es>Detalle del campo</es>
-            <fr>Détail du champ</fr>
+            <fr>DÃ©tail du champ</fr>
             <it>Dettaglio campo</it>
-            <pl>Szczegóły pola</pl>
-            <ru>Сведения о поле</ru>
-            <uk>Деталі поля</uk>
+            <pl>SzczegÃ³Å‚y pola</pl>
+            <ru>Ð¡Ð²ÐµÐ´ÐµÐ½Ð¸Ñ Ð¾ Ð¿Ð¾Ð»Ðµ</ru>
+            <uk>Ð”ÐµÑ‚Ð°Ð»Ñ– Ð¿Ð¾Ð»Ñ</uk>
             <nl>Veldgegevens</nl>
             <pt>Detalhe do campo</pt>
-            <sv>Fältdetaljer</sv>
+            <sv>FÃ¤ltdetaljer</sv>
             <no>Feltdetaljer</no>
             <fi>Pellon tiedot</fi>
-            <hu>Táblarészletek</hu>
-            <ro>Detaliu câmp</ro>
-            <tr>Tarla detayı</tr>
-            <jp>畑の詳細</jp>
-            <kr>밯 상세</kr>
-            <ct>田地詳情</ct>
-            <fc>Détail du champ</fc>
+            <hu>TÃ¡blarÃ©szletek</hu>
+            <ro>Detaliu cÃ¢mp</ro>
+            <tr>Tarla detayÄ±</tr>
+            <jp>ç•‘ã®è©³ç´°</jp>
+            <kr>ë°¯ ìƒì„¸</kr>
+            <ct>ç”°åœ°è©³æƒ…</ct>
+            <fc>DÃ©tail du champ</fc>
             <ea>Detalle del campo</ea>
             <id>Detail lahan</id>
-            <vi>Chi tiết thửa ruộng</vi>
+            <vi>Chi tiáº¿t thá»­a ruá»™ng</vi>
         </text>
 </l10n>
 

--- a/xml/gui/RfPdaMenuPage.xml
+++ b/xml/gui/RfPdaMenuPage.xml
@@ -209,18 +209,30 @@
 
                         <!-- Card 2 of 3 (BUILD 12:59): Selected + Next now live INSIDE the
                              PRODUCTS card, so the card owns the whole middle column. -->
-                        <GuiElement profile="RF_EscCardFrame" id="treatProductsShell" position="220px -22px">
-                            <Text profile="RF_TreatSelected" id="treatSelectedLabel" position="10px -6px" size="540px 20px"
+                        <!-- GO 21:06 (BUILD 21:01): PRODUCTS was inheriting 560 from
+                             RF_EscCardFrame, so its right edge sat at 220 + 560 = 780 against
+                             ROTATION at 850: a dark 70px canyon down the middle of a three-card
+                             family. The inline 620 lands the right edge on 840, leaving 10px of
+                             air, and TREATMENT already ends at 210 against PRODUCTS at 220, so
+                             both gutters read as the same gap. Family rhythm, not a kiss.
+                             Bodies follow 540 -> 600 in step so the 10px left inset is kept and
+                             nothing is re-centred; RATE and TOTAL keep their left-anchored
+                             recipe and simply gain trailing air.
+                             This edit is in ALL NINE door copies on purpose. The Esc page is
+                             built by whichever mod loads first, from its own copy, so a change
+                             in Soil alone would be overwritten by whoever won the race. -->
+                        <GuiElement profile="RF_EscCardFrame" id="treatProductsShell" position="220px -22px" size="620px 248px">
+                            <Text profile="RF_TreatSelected" id="treatSelectedLabel" position="10px -6px" size="600px 20px"
                                   textAlignment="left"/>
-                            <Text profile="RF_TreatNext" id="treatNextLabel" position="10px -26px" size="540px 36px"
+                            <Text profile="RF_TreatNext" id="treatNextLabel" position="10px -26px" size="600px 36px"
                                   textAlignment="left" textMaxNumLines="2" textVerticalAlignment="top"/>
                             <!-- Zone split (BUILD 16:19): Selected + Next stay on top, then ~16px of
                                  air with one 1px hairline centred in it, then the PRODUCTS table.
                                  One outer outline only; the rule is a Bitmap, not a second frame.
                                  Bodies inset X 0 -> 10 and widths 560 -> 540 so nothing kisses the
                                  white stroke on either side. -->
-                            <Bitmap profile="RF_EscCardRule" id="treatProductsRule" position="10px -70px" size="540px 1px"/>
-                            <Text profile="RF_ProductsTitle" id="soilTreatProducts" position="10px -80px" size="540px 18px"
+                            <Bitmap profile="RF_EscCardRule" id="treatProductsRule" position="10px -70px" size="600px 1px"/>
+                            <Text profile="RF_ProductsTitle" id="soilTreatProducts" position="10px -80px" size="600px 18px"
                                   text="$l10n_rf_pda_treat_products"/>
                             <Text profile="RF_ProductColHeaderDense" position="10px -100px" size="40px 16px" text="NUT"/>
                             <Text profile="RF_ProductColHeaderDense" position="54px -100px" size="270px 16px" text="PRODUCT"/>
@@ -228,54 +240,54 @@
                                   textAlignment="right" text="RATE"/>
                             <Text profile="RF_ProductColHeaderDense" position="440px -100px" size="110px 16px"
                                   textAlignment="right" text="TOTAL"/>
-                            <Text profile="RF_ProductOk" id="treatPlanLines" position="10px -120px" size="540px 22px"
+                            <Text profile="RF_ProductOk" id="treatPlanLines" position="10px -120px" size="600px 22px"
                                   visible="false"/>
                             <!-- Clip sized to exactly the eight densified rows (8 x 15 = 120), so the
                                  card bottom keeps 8px of air instead of cutting row 8 mid-glyph. -->
-                            <GuiElement profile="RF_ProductsRowsClip" id="treatProdRowsClip" position="10px -120px" size="540px 120px">
-                                <GuiElement profile="RF_ProductRow" id="treatProdRow1" position="0px 0px" size="540px 15px" visible="false">
+                            <GuiElement profile="RF_ProductsRowsClip" id="treatProdRowsClip" position="10px -120px" size="600px 120px">
+                                <GuiElement profile="RF_ProductRow" id="treatProdRow1" position="0px 0px" size="600px 15px" visible="false">
                                     <Text profile="RF_ProductCellDense" id="treatProd1Nut" position="0px 0px" size="40px 15px"/>
                                     <Text profile="RF_ProductCellDense" id="treatProd1Name" position="44px 0px" size="270px 15px"/>
                                     <Text profile="RF_ProductCellDenseRight" id="treatProd1Rate" position="320px 0px" size="100px 15px"/>
                                     <Text profile="RF_ProductCellDenseRight" id="treatProd1Total" position="430px 0px" size="110px 15px"/>
                                 </GuiElement>
-                                <GuiElement profile="RF_ProductRow" id="treatProdRow2" position="0px -15px" size="540px 15px" visible="false">
+                                <GuiElement profile="RF_ProductRow" id="treatProdRow2" position="0px -15px" size="600px 15px" visible="false">
                                     <Text profile="RF_ProductCellDense" id="treatProd2Nut" position="0px 0px" size="40px 15px"/>
                                     <Text profile="RF_ProductCellDense" id="treatProd2Name" position="44px 0px" size="270px 15px"/>
                                     <Text profile="RF_ProductCellDenseRight" id="treatProd2Rate" position="320px 0px" size="100px 15px"/>
                                     <Text profile="RF_ProductCellDenseRight" id="treatProd2Total" position="430px 0px" size="110px 15px"/>
                                 </GuiElement>
-                                <GuiElement profile="RF_ProductRow" id="treatProdRow3" position="0px -30px" size="540px 15px" visible="false">
+                                <GuiElement profile="RF_ProductRow" id="treatProdRow3" position="0px -30px" size="600px 15px" visible="false">
                                     <Text profile="RF_ProductCellDense" id="treatProd3Nut" position="0px 0px" size="40px 15px"/>
                                     <Text profile="RF_ProductCellDense" id="treatProd3Name" position="44px 0px" size="270px 15px"/>
                                     <Text profile="RF_ProductCellDenseRight" id="treatProd3Rate" position="320px 0px" size="100px 15px"/>
                                     <Text profile="RF_ProductCellDenseRight" id="treatProd3Total" position="430px 0px" size="110px 15px"/>
                                 </GuiElement>
-                                <GuiElement profile="RF_ProductRow" id="treatProdRow4" position="0px -45px" size="540px 15px" visible="false">
+                                <GuiElement profile="RF_ProductRow" id="treatProdRow4" position="0px -45px" size="600px 15px" visible="false">
                                     <Text profile="RF_ProductCellDense" id="treatProd4Nut" position="0px 0px" size="40px 15px"/>
                                     <Text profile="RF_ProductCellDense" id="treatProd4Name" position="44px 0px" size="270px 15px"/>
                                     <Text profile="RF_ProductCellDenseRight" id="treatProd4Rate" position="320px 0px" size="100px 15px"/>
                                     <Text profile="RF_ProductCellDenseRight" id="treatProd4Total" position="430px 0px" size="110px 15px"/>
                                 </GuiElement>
-                                <GuiElement profile="RF_ProductRow" id="treatProdRow5" position="0px -60px" size="540px 15px" visible="false">
+                                <GuiElement profile="RF_ProductRow" id="treatProdRow5" position="0px -60px" size="600px 15px" visible="false">
                                     <Text profile="RF_ProductCellDense" id="treatProd5Nut" position="0px 0px" size="40px 15px"/>
                                     <Text profile="RF_ProductCellDense" id="treatProd5Name" position="44px 0px" size="270px 15px"/>
                                     <Text profile="RF_ProductCellDenseRight" id="treatProd5Rate" position="320px 0px" size="100px 15px"/>
                                     <Text profile="RF_ProductCellDenseRight" id="treatProd5Total" position="430px 0px" size="110px 15px"/>
                                 </GuiElement>
-                                <GuiElement profile="RF_ProductRow" id="treatProdRow6" position="0px -75px" size="540px 15px" visible="false">
+                                <GuiElement profile="RF_ProductRow" id="treatProdRow6" position="0px -75px" size="600px 15px" visible="false">
                                     <Text profile="RF_ProductCellDense" id="treatProd6Nut" position="0px 0px" size="40px 15px"/>
                                     <Text profile="RF_ProductCellDense" id="treatProd6Name" position="44px 0px" size="270px 15px"/>
                                     <Text profile="RF_ProductCellDenseRight" id="treatProd6Rate" position="320px 0px" size="100px 15px"/>
                                     <Text profile="RF_ProductCellDenseRight" id="treatProd6Total" position="430px 0px" size="110px 15px"/>
                                 </GuiElement>
-                                <GuiElement profile="RF_ProductRow" id="treatProdRow7" position="0px -90px" size="540px 15px" visible="false">
+                                <GuiElement profile="RF_ProductRow" id="treatProdRow7" position="0px -90px" size="600px 15px" visible="false">
                                     <Text profile="RF_ProductCellDense" id="treatProd7Nut" position="0px 0px" size="40px 15px"/>
                                     <Text profile="RF_ProductCellDense" id="treatProd7Name" position="44px 0px" size="270px 15px"/>
                                     <Text profile="RF_ProductCellDenseRight" id="treatProd7Rate" position="320px 0px" size="100px 15px"/>
                                     <Text profile="RF_ProductCellDenseRight" id="treatProd7Total" position="430px 0px" size="110px 15px"/>
                                 </GuiElement>
-                                <GuiElement profile="RF_ProductRow" id="treatProdRow8" position="0px -105px" size="540px 15px" visible="false">
+                                <GuiElement profile="RF_ProductRow" id="treatProdRow8" position="0px -105px" size="600px 15px" visible="false">
                                     <Text profile="RF_ProductCellDense" id="treatProd8Nut" position="0px 0px" size="40px 15px"/>
                                     <Text profile="RF_ProductCellDense" id="treatProd8Name" position="44px 0px" size="270px 15px"/>
                                     <Text profile="RF_ProductCellDenseRight" id="treatProd8Rate" position="320px 0px" size="100px 15px"/>
@@ -341,58 +353,80 @@
                     <!-- Worker Costs page bodies only (page chrome = left sibling band). -->
                     <GuiElement profile="RF_WcPageShell" id="wcPageShell" visible="false">
                         <!-- Dashboard -->
-                        <GuiElement profile="RF_WcPage" id="wcPageDashboard" visible="true">
-                            <Text profile="RF_TreatTargetLine" id="wcDashStatus" position="0px 0px" size="1140px 22px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="wcDashMode" position="0px -48px" size="560px 22px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="wcDashWage" position="580px -48px" size="560px 22px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="wcDashRate" position="0px -96px" size="560px 22px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="wcDashWorkers" position="580px -96px" size="560px 22px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="wcDashEstimate" position="0px -144px" size="560px 22px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="wcDashCountdown" position="580px -144px" size="560px 22px" text=""/>
-                            <Text profile="RF_HintText" id="wcDashWorkerNames" position="0px -200px" size="1140px 280px"
+                        <!-- Dashboard is the only WC page that gets the white card (Ash 15:35 #2):
+                             Wages/Workers/About carry MTOs and their own chrome. Framed on
+                             wcPageDashboard itself, not a new inner shell, so nothing double-frames.
+                             Body cells inset 10px L/R and 8px down; worker names still 280 tall and
+                             end at -488 of 500, so 12px of bottom air and no clip. -->
+                        <GuiElement profile="RF_EscCardFrameWide" id="wcPageDashboard" visible="true">
+                            <Text profile="RF_TreatTargetLine" id="wcDashStatus" position="10px -8px" size="1120px 22px" text=""/>
+                            <Text profile="RF_TreatTargetLine" id="wcDashMode" position="10px -56px" size="550px 22px" text=""/>
+                            <Text profile="RF_TreatTargetLine" id="wcDashWage" position="580px -56px" size="550px 22px" text=""/>
+                            <Text profile="RF_TreatTargetLine" id="wcDashRate" position="10px -104px" size="550px 22px" text=""/>
+                            <Text profile="RF_TreatTargetLine" id="wcDashWorkers" position="580px -104px" size="550px 22px" text=""/>
+                            <Text profile="RF_TreatTargetLine" id="wcDashEstimate" position="10px -152px" size="550px 22px" text=""/>
+                            <Text profile="RF_TreatTargetLine" id="wcDashCountdown" position="580px -152px" size="550px 22px" text=""/>
+                            <Text profile="RF_HintText" id="wcDashWorkerNames" position="10px -208px" size="1120px 280px"
                                   textMaxNumLines="12" textVerticalAlignment="top" text=""/>
                         </GuiElement>
 
                         <!-- Wages: tight label+option rows; summary/help/Reset UNDER stack (no 760 side column). -->
+                        <!-- Two cards, not one: settings stack up, summary/help/Reset below, 16px of
+                             clear air between the strokes. The page itself stays unframed - a frame on
+                             RF_WcPage would be the mega-shell over the MTOs George vetoed. Wrappers carry
+                             handleFocus=false so nothing between the player and an option can take a click,
+                             and the MTOs are still found by getDescendantById, which does not care how deep
+                             they sit. Card B trims one internal gap by 8px, which is exactly what the two
+                             strokes plus their air cost, so wcBtnWageReset lands back on -536 and the page
+                             stays 580 tall. Nothing grew to make room. -->
                         <GuiElement profile="RF_WcPage" id="wcPageWages" size="1140px 580px" visible="false">
-                            <Text profile="RF_TreatTargetLine" id="wcWageLblEnabled" position="0px 8px" size="200px 22px" text=""/>
-                            <MultiTextOption profile="RF_WcWageOption" id="wcOptEnabled" position="220px 0px"
-                                             disableButtonsOnSingleText="false" onClick="onClickWcWageOption"/>
-                            <Text profile="RF_TreatTargetLine" id="wcWageLblMode" position="0px -44px" size="200px 22px" text=""/>
-                            <MultiTextOption profile="RF_WcWageOption" id="wcOptCostMode" position="220px -52px"
-                                             disableButtonsOnSingleText="false" onClick="onClickWcWageOption"/>
-                            <Text profile="RF_TreatTargetLine" id="wcWageLblLevel" position="0px -96px" size="200px 22px" text=""/>
-                            <MultiTextOption profile="RF_WcWageOption" id="wcOptWageLevel" position="220px -104px"
-                                             disableButtonsOnSingleText="false" onClick="onClickWcWageOption"/>
-                            <Text profile="RF_TreatTargetLine" id="wcWageLblNotify" position="0px -148px" size="200px 22px" text=""/>
-                            <MultiTextOption profile="RF_WcWageOption" id="wcOptNotifications" position="220px -156px"
-                                             disableButtonsOnSingleText="false" onClick="onClickWcWageOption"/>
-                            <Text profile="RF_TreatTargetLine" id="wcWageLblDebug" position="0px -200px" size="200px 22px" text=""/>
-                            <MultiTextOption profile="RF_WcWageOption" id="wcOptDebugMode" position="220px -208px"
-                                             disableButtonsOnSingleText="false" onClick="onClickWcWageOption"/>
-                            <Text profile="RF_TreatTargetLine" id="wcWageLblSalary" position="0px -252px" size="200px 22px" text=""/>
-                            <MultiTextOption profile="RF_WcWageOption" id="wcOptMonthlySalary" position="220px -260px"
-                                             disableButtonsOnSingleText="false" onClick="onClickWcWageOption"/>
-                            <!-- Summary band under last option (~-260); full width; not overlapping options. -->
-                            <Text profile="RF_SectionTitle" id="wcWageBigRate" position="0px -340px" size="1140px 36px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="wcWageRateLabel" position="0px -384px" size="560px 22px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="wcWagePayInterval" position="580px -384px" size="560px 22px" text=""/>
-                            <Text profile="RF_HintText" id="wcWageHelpBody" position="0px -420px" size="1140px 100px"
-                                  textMaxNumLines="4" textVerticalAlignment="top" text=""/>
-                            <Button profile="buttonActivate" id="wcBtnWageReset" position="0px -536px" size="200px 36px"
-                                    text="Reset" onClick="onClickWcWageReset"/>
+                            <GuiElement profile="RF_EscCardFrameWide" id="wcWagesCardA" position="0px 0px" size="1140px 326px" handleFocus="false">
+                                <Text profile="RF_TreatTargetLine" id="wcWageLblEnabled" position="10px -10px" size="200px 22px" text=""/>
+                                <MultiTextOption profile="RF_WcWageOption" id="wcOptEnabled" position="230px -18px"
+                                                 disableButtonsOnSingleText="false" onClick="onClickWcWageOption"/>
+                                <Text profile="RF_TreatTargetLine" id="wcWageLblMode" position="10px -62px" size="200px 22px" text=""/>
+                                <MultiTextOption profile="RF_WcWageOption" id="wcOptCostMode" position="230px -70px"
+                                                 disableButtonsOnSingleText="false" onClick="onClickWcWageOption"/>
+                                <Text profile="RF_TreatTargetLine" id="wcWageLblLevel" position="10px -114px" size="200px 22px" text=""/>
+                                <MultiTextOption profile="RF_WcWageOption" id="wcOptWageLevel" position="230px -122px"
+                                                 disableButtonsOnSingleText="false" onClick="onClickWcWageOption"/>
+                                <Text profile="RF_TreatTargetLine" id="wcWageLblNotify" position="10px -166px" size="200px 22px" text=""/>
+                                <MultiTextOption profile="RF_WcWageOption" id="wcOptNotifications" position="230px -174px"
+                                                 disableButtonsOnSingleText="false" onClick="onClickWcWageOption"/>
+                                <Text profile="RF_TreatTargetLine" id="wcWageLblDebug" position="10px -218px" size="200px 22px" text=""/>
+                                <MultiTextOption profile="RF_WcWageOption" id="wcOptDebugMode" position="230px -226px"
+                                                 disableButtonsOnSingleText="false" onClick="onClickWcWageOption"/>
+                                <Text profile="RF_TreatTargetLine" id="wcWageLblSalary" position="10px -270px" size="200px 22px" text=""/>
+                                <MultiTextOption profile="RF_WcWageOption" id="wcOptMonthlySalary" position="230px -278px"
+                                                 disableButtonsOnSingleText="false" onClick="onClickWcWageOption"/>
+                            </GuiElement>
+                            <GuiElement profile="RF_EscCardFrameWide" id="wcWagesCardB" position="0px -342px" size="1140px 238px" handleFocus="false">
+                                <Text profile="RF_SectionTitle" id="wcWageBigRate" position="10px -6px" size="1120px 36px" text=""/>
+                                <Text profile="RF_TreatTargetLine" id="wcWageRateLabel" position="10px -50px" size="550px 22px" text=""/>
+                                <Text profile="RF_TreatTargetLine" id="wcWagePayInterval" position="580px -50px" size="550px 22px" text=""/>
+                                <Text profile="RF_HintText" id="wcWageHelpBody" position="10px -86px" size="1120px 100px"
+                                      textMaxNumLines="4" textVerticalAlignment="top" text=""/>
+                                <Button profile="buttonActivate" id="wcBtnWageReset" position="10px -194px" size="200px 36px"
+                                        text="Reset" onClick="onClickWcWageReset"/>
+                            </GuiElement>
                         </GuiElement>
 
                         <!-- Workers -->
+                        <!-- Same family as Wages: stats card, 16px of air, then the worker list card.
+                             wcStatsWorkerList stays fixed Text rows, no SmoothList. -->
                         <GuiElement profile="RF_WcPage" id="wcPageWorkers" visible="false">
-                            <Text profile="RF_TreatTargetLine" id="wcStatsMode" position="0px 0px" size="560px 22px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="wcStatsWage" position="580px 0px" size="560px 22px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="wcStatsInterval" position="0px -48px" size="560px 22px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="wcStatsCount" position="580px -48px" size="560px 22px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="wcStatsCostPer" position="0px -96px" size="560px 22px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="wcStatsTotal" position="580px -96px" size="560px 22px" text=""/>
-                            <Text profile="RF_HintText" id="wcStatsWorkerList" position="0px -160px" size="1140px 320px"
-                                  textMaxNumLines="14" textVerticalAlignment="top" text=""/>
+                            <GuiElement profile="RF_EscCardFrameWide" id="wcWorkersCardA" position="0px 0px" size="1140px 136px" handleFocus="false">
+                                <Text profile="RF_TreatTargetLine" id="wcStatsMode" position="10px -10px" size="550px 22px" text=""/>
+                                <Text profile="RF_TreatTargetLine" id="wcStatsWage" position="580px -10px" size="550px 22px" text=""/>
+                                <Text profile="RF_TreatTargetLine" id="wcStatsInterval" position="10px -58px" size="550px 22px" text=""/>
+                                <Text profile="RF_TreatTargetLine" id="wcStatsCount" position="580px -58px" size="550px 22px" text=""/>
+                                <Text profile="RF_TreatTargetLine" id="wcStatsCostPer" position="10px -106px" size="550px 22px" text=""/>
+                                <Text profile="RF_TreatTargetLine" id="wcStatsTotal" position="580px -106px" size="550px 22px" text=""/>
+                            </GuiElement>
+                            <GuiElement profile="RF_EscCardFrameWide" id="wcWorkersCardB" position="0px -152px" size="1140px 338px" handleFocus="false">
+                                <Text profile="RF_HintText" id="wcStatsWorkerList" position="10px -10px" size="1120px 320px"
+                                      textMaxNumLines="14" textVerticalAlignment="top" text=""/>
+                            </GuiElement>
                         </GuiElement>
 
                         <!-- About page retired 2026-08-02: copy lives in wcSideInfoShell. Keep shell for nil-safe ids. -->
@@ -417,61 +451,84 @@
                          Text-only; no onClick. Visible only for framework module ids.
                          George 2026-08-05: shell 0/-20 (X flush + B1 blurb-48 clearance); titles hidden; rows +36. -->
                     <GuiElement profile="RF_WcPageShell" id="rfFrameworkGlanceShell" visible="false" position="0px 0px">
-                        <GuiElement id="rfFwStatusBlock" visible="true" position="0px 0px" size="1140px 580px">
-                            <Text profile="RF_SectionTitle" id="rfFwStatusTitle" position="0px 0px" size="1140px 24px" text="" visible="false"/>
-                            <Text profile="RF_TreatTargetLine" id="rfFwLine1" position="0px 0px" size="560px 22px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="rfFwLine2" position="0px -48px" size="560px 22px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="rfFwLine3" position="0px -96px" size="560px 22px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="rfFwLine4" position="0px -144px" size="560px 22px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="rfFwLine5" position="580px 0px" size="560px 22px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="rfFwLine6" position="580px -48px" size="560px 22px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="rfFwLine7" position="580px -96px" size="560px 22px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="rfFwLine8" position="580px -144px" size="560px 22px" text=""/>
-                            <Text profile="RF_HintText" id="rfFwHint" position="0px -200px" size="1140px 120px"
+                        <!-- Income / Tax / Depot status glance. 580 was taller than the shell (520);
+                             the card is sized to its content instead: hint ends at -328, so 340
+                             leaves 12px of bottom air inside the stroke. -->
+                        <GuiElement profile="RF_EscCardFrameWide" id="rfFwStatusBlock" visible="true" position="0px 0px" size="1140px 340px">
+                            <Text profile="RF_SectionTitle" id="rfFwStatusTitle" position="10px -8px" size="1120px 24px" text="" visible="false"/>
+                            <Text profile="RF_TreatTargetLine" id="rfFwLine1" position="10px -8px" size="550px 22px" text=""/>
+                            <Text profile="RF_TreatTargetLine" id="rfFwLine2" position="10px -56px" size="550px 22px" text=""/>
+                            <Text profile="RF_TreatTargetLine" id="rfFwLine3" position="10px -104px" size="550px 22px" text=""/>
+                            <Text profile="RF_TreatTargetLine" id="rfFwLine4" position="10px -152px" size="550px 22px" text=""/>
+                            <Text profile="RF_TreatTargetLine" id="rfFwLine5" position="580px -8px" size="550px 22px" text=""/>
+                            <Text profile="RF_TreatTargetLine" id="rfFwLine6" position="580px -56px" size="550px 22px" text=""/>
+                            <Text profile="RF_TreatTargetLine" id="rfFwLine7" position="580px -104px" size="550px 22px" text=""/>
+                            <Text profile="RF_TreatTargetLine" id="rfFwLine8" position="580px -152px" size="550px 22px" text=""/>
+                            <Text profile="RF_HintText" id="rfFwHint" position="10px -208px" size="1120px 120px"
                                   textMaxNumLines="4" textVerticalAlignment="top" text=""/>
                         </GuiElement>
-                        <GuiElement id="rfFwTableBlock" visible="false" position="0px 0px" size="1140px 580px">
-                            <Text profile="RF_SectionTitle" id="rfFwTableTitle" position="0px 0px" size="1140px 24px" text="" visible="false"/>
-                            <Text profile="RF_ColHeader" id="rfFwColA" position="0px -32px" size="280px 22px" text=""/>
-                            <Text profile="RF_ColHeader" id="rfFwColB" position="300px -32px" size="280px 22px" text=""/>
-                            <Text profile="RF_ColHeader" id="rfFwColC" position="600px -32px" size="220px 22px" text=""/>
-                            <Text profile="RF_ColHeader" id="rfFwColD" position="840px -32px" size="280px 22px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="rfFwRow1A" position="0px -60px" size="280px 20px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="rfFwRow1B" position="300px -60px" size="280px 20px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="rfFwRow1C" position="600px -60px" size="220px 20px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="rfFwRow1D" position="840px -60px" size="280px 20px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="rfFwRow2A" position="0px -88px" size="280px 20px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="rfFwRow2B" position="300px -88px" size="280px 20px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="rfFwRow2C" position="600px -88px" size="220px 20px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="rfFwRow2D" position="840px -88px" size="280px 20px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="rfFwRow3A" position="0px -116px" size="280px 20px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="rfFwRow3B" position="300px -116px" size="280px 20px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="rfFwRow3C" position="600px -116px" size="220px 20px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="rfFwRow3D" position="840px -116px" size="280px 20px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="rfFwRow4A" position="0px -144px" size="280px 20px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="rfFwRow4B" position="300px -144px" size="280px 20px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="rfFwRow4C" position="600px -144px" size="220px 20px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="rfFwRow4D" position="840px -144px" size="280px 20px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="rfFwRow5A" position="0px -172px" size="280px 20px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="rfFwRow5B" position="300px -172px" size="280px 20px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="rfFwRow5C" position="600px -172px" size="220px 20px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="rfFwRow5D" position="840px -172px" size="280px 20px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="rfFwRow6A" position="0px -200px" size="280px 20px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="rfFwRow6B" position="300px -200px" size="280px 20px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="rfFwRow6C" position="600px -200px" size="220px 20px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="rfFwRow6D" position="840px -200px" size="280px 20px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="rfFwRow7A" position="0px -228px" size="280px 20px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="rfFwRow7B" position="300px -228px" size="280px 20px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="rfFwRow7C" position="600px -228px" size="220px 20px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="rfFwRow7D" position="840px -228px" size="280px 20px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="rfFwRow8A" position="0px -256px" size="280px 20px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="rfFwRow8B" position="300px -256px" size="280px 20px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="rfFwRow8C" position="600px -256px" size="220px 20px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="rfFwRow8D" position="840px -256px" size="280px 20px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="rfFwMore" position="0px -292px" size="1140px 20px" text=""/>
-                            <Text profile="RF_HintText" id="rfFwEmptyHint" position="0px -60px" size="1140px 44px"
+                        <!-- Dairy / NPC Favor table glance. Content runs to -416 (hint under the rows),
+                             so 428 gives the same 12px of bottom air. Only one of the two blocks is
+                             ever visible (setVis is an either/or), so no card is ever naked beside
+                             another - Ash 15:35 #1 sibling framing has nothing to bite on here. -->
+                        <GuiElement profile="RF_EscCardFrameWide" id="rfFwTableBlock" visible="false" position="0px 0px" size="1140px 428px">
+                            <Text profile="RF_SectionTitle" id="rfFwTableTitle" position="10px -8px" size="1120px 24px" text="" visible="false"/>
+                            <!-- Excel sheet: the outer border is rfFwTableBlock's own hasFrame; these 11 hairlines
+                                 are the inner grid. RF_EscCardRule is already blank.png + soft grey 0.55, so they
+                                 take it with an inline size rather than one profile per orientation. Declared
+                                 before the cells so text paints over them. Per-cell hasFrame would have been 144
+                                 frame rects for the same picture. -->
+                            <Bitmap profile="RF_EscCardRule" id="rfFwRuleHead" position="10px -64px" size="1120px 1px"/>
+                            <Bitmap profile="RF_EscCardRule" id="rfFwRuleRow1" position="10px -92px" size="1120px 1px"/>
+                            <Bitmap profile="RF_EscCardRule" id="rfFwRuleRow2" position="10px -120px" size="1120px 1px"/>
+                            <Bitmap profile="RF_EscCardRule" id="rfFwRuleRow3" position="10px -148px" size="1120px 1px"/>
+                            <Bitmap profile="RF_EscCardRule" id="rfFwRuleRow4" position="10px -176px" size="1120px 1px"/>
+                            <Bitmap profile="RF_EscCardRule" id="rfFwRuleRow5" position="10px -204px" size="1120px 1px"/>
+                            <Bitmap profile="RF_EscCardRule" id="rfFwRuleRow6" position="10px -232px" size="1120px 1px"/>
+                            <Bitmap profile="RF_EscCardRule" id="rfFwRuleRow7" position="10px -260px" size="1120px 1px"/>
+                            <Bitmap profile="RF_EscCardRule" id="rfFwRuleCol1" position="300px -36px" size="1px 250px"/>
+                            <Bitmap profile="RF_EscCardRule" id="rfFwRuleCol2" position="600px -36px" size="1px 250px"/>
+                            <Bitmap profile="RF_EscCardRule" id="rfFwRuleCol3" position="840px -36px" size="1px 250px"/>
+                            <Text profile="RF_FwColHeader" id="rfFwColA" position="10px -40px" size="280px 22px" text=""/>
+                            <Text profile="RF_FwColHeader" id="rfFwColB" position="310px -40px" size="280px 22px" text=""/>
+                            <Text profile="RF_FwColHeader" id="rfFwColC" position="610px -40px" size="220px 22px" text=""/>
+                            <Text profile="RF_FwColHeader" id="rfFwColD" position="850px -40px" size="280px 22px" text=""/>
+                            <Text profile="RF_TreatTargetLine" id="rfFwRow1A" position="10px -68px" size="280px 20px" text=""/>
+                            <Text profile="RF_TreatTargetLine" id="rfFwRow1B" position="310px -68px" size="280px 20px" text=""/>
+                            <Text profile="RF_TreatTargetLine" id="rfFwRow1C" position="610px -68px" size="220px 20px" text=""/>
+                            <Text profile="RF_TreatTargetLine" id="rfFwRow1D" position="850px -68px" size="280px 20px" text=""/>
+                            <Text profile="RF_TreatTargetLine" id="rfFwRow2A" position="10px -96px" size="280px 20px" text=""/>
+                            <Text profile="RF_TreatTargetLine" id="rfFwRow2B" position="310px -96px" size="280px 20px" text=""/>
+                            <Text profile="RF_TreatTargetLine" id="rfFwRow2C" position="610px -96px" size="220px 20px" text=""/>
+                            <Text profile="RF_TreatTargetLine" id="rfFwRow2D" position="850px -96px" size="280px 20px" text=""/>
+                            <Text profile="RF_TreatTargetLine" id="rfFwRow3A" position="10px -124px" size="280px 20px" text=""/>
+                            <Text profile="RF_TreatTargetLine" id="rfFwRow3B" position="310px -124px" size="280px 20px" text=""/>
+                            <Text profile="RF_TreatTargetLine" id="rfFwRow3C" position="610px -124px" size="220px 20px" text=""/>
+                            <Text profile="RF_TreatTargetLine" id="rfFwRow3D" position="850px -124px" size="280px 20px" text=""/>
+                            <Text profile="RF_TreatTargetLine" id="rfFwRow4A" position="10px -152px" size="280px 20px" text=""/>
+                            <Text profile="RF_TreatTargetLine" id="rfFwRow4B" position="310px -152px" size="280px 20px" text=""/>
+                            <Text profile="RF_TreatTargetLine" id="rfFwRow4C" position="610px -152px" size="220px 20px" text=""/>
+                            <Text profile="RF_TreatTargetLine" id="rfFwRow4D" position="850px -152px" size="280px 20px" text=""/>
+                            <Text profile="RF_TreatTargetLine" id="rfFwRow5A" position="10px -180px" size="280px 20px" text=""/>
+                            <Text profile="RF_TreatTargetLine" id="rfFwRow5B" position="310px -180px" size="280px 20px" text=""/>
+                            <Text profile="RF_TreatTargetLine" id="rfFwRow5C" position="610px -180px" size="220px 20px" text=""/>
+                            <Text profile="RF_TreatTargetLine" id="rfFwRow5D" position="850px -180px" size="280px 20px" text=""/>
+                            <Text profile="RF_TreatTargetLine" id="rfFwRow6A" position="10px -208px" size="280px 20px" text=""/>
+                            <Text profile="RF_TreatTargetLine" id="rfFwRow6B" position="310px -208px" size="280px 20px" text=""/>
+                            <Text profile="RF_TreatTargetLine" id="rfFwRow6C" position="610px -208px" size="220px 20px" text=""/>
+                            <Text profile="RF_TreatTargetLine" id="rfFwRow6D" position="850px -208px" size="280px 20px" text=""/>
+                            <Text profile="RF_TreatTargetLine" id="rfFwRow7A" position="10px -236px" size="280px 20px" text=""/>
+                            <Text profile="RF_TreatTargetLine" id="rfFwRow7B" position="310px -236px" size="280px 20px" text=""/>
+                            <Text profile="RF_TreatTargetLine" id="rfFwRow7C" position="610px -236px" size="220px 20px" text=""/>
+                            <Text profile="RF_TreatTargetLine" id="rfFwRow7D" position="850px -236px" size="280px 20px" text=""/>
+                            <Text profile="RF_TreatTargetLine" id="rfFwRow8A" position="10px -264px" size="280px 20px" text=""/>
+                            <Text profile="RF_TreatTargetLine" id="rfFwRow8B" position="310px -264px" size="280px 20px" text=""/>
+                            <Text profile="RF_TreatTargetLine" id="rfFwRow8C" position="610px -264px" size="220px 20px" text=""/>
+                            <Text profile="RF_TreatTargetLine" id="rfFwRow8D" position="850px -264px" size="280px 20px" text=""/>
+                            <Text profile="RF_TreatTargetLine" id="rfFwMore" position="10px -300px" size="1120px 20px" text=""/>
+                            <Text profile="RF_HintText" id="rfFwEmptyHint" position="10px -68px" size="1120px 44px"
                                   textMaxNumLines="2" visible="false" text=""/>
-                            <Text profile="RF_HintText" id="rfFwHintTable" position="0px -328px" size="1140px 80px"
+                            <Text profile="RF_HintText" id="rfFwHintTable" position="10px -336px" size="1120px 80px"
                                   textMaxNumLines="3" textVerticalAlignment="top" text=""/>
                         </GuiElement>
                     </GuiElement>
@@ -710,23 +767,23 @@
                         <Bitmap profile="RF_TreatmentBoxBg"/>
 
                         <!-- Page A — Prices -->
-                        <GuiElement id="mdPricesBand" visible="true" position="0px 0px" size="100% 100%">
+                        <GuiElement profile="RF_EscCardFrameWide" id="mdPricesBand" visible="true" position="10px -10px" size="1130px 344px">
                             <Text profile="RF_SectionTitle" id="mdGraphTitle" position="10px -6px" size="700px 22px" text=""/>
-                            <GuiElement profile="RF_MdGraphArea" id="mdGraphArea"/>
-            <Text profile="RF_EmptyHint" id="mdGraphEmptyHint" position="40px -96px" size="720px 40px"
+                            <GuiElement profile="RF_MdGraphArea" id="mdGraphArea" position="30px -28px"/>
+            <Text profile="RF_EmptyHint" id="mdGraphEmptyHint" position="30px -86px" size="720px 40px"
                   visible="false" text=""/>
-            <Text profile="RF_TreatSelected" id="mdDetailCommodity" position="770px -32px" size="380px 22px"
+            <Text profile="RF_TreatSelected" id="mdDetailCommodity" position="770px -32px" size="350px 22px"
                   textAlignment="left" text=""/>
-            <Text profile="RF_TreatTargetLine" id="mdDetailPrice" position="770px -64px" size="380px 20px" text=""/>
-            <Text profile="RF_TreatTargetLine" id="mdDetailPressure" position="770px -92px" size="380px 20px" text=""/>
-            <Text profile="RF_HintText" id="mdDetailEmpty" position="770px -64px" size="380px 44px"
+            <Text profile="RF_TreatTargetLine" id="mdDetailPrice" position="770px -64px" size="350px 20px" text=""/>
+            <Text profile="RF_TreatTargetLine" id="mdDetailPressure" position="770px -92px" size="350px 20px" text=""/>
+            <Text profile="RF_HintText" id="mdDetailEmpty" position="770px -64px" size="350px 44px"
                   textMaxNumLines="2" visible="false" text=""/>
-            <Button profile="buttonActivate" id="mdOpenMarketBtn" position="770px -280px" size="360px 36px"
+            <Button profile="buttonActivate" id="mdOpenMarketBtn" position="770px -280px" size="350px 36px"
                     onClick="onClickMdOpenMarket"/>
                         </GuiElement>
 
                         <!-- Page B — Events (fixed Text rows; no SmoothList thrash). -->
-                        <GuiElement id="mdEventsBand" visible="false" position="0px 0px" size="100% 100%">
+                        <GuiElement profile="RF_EscCardFrameWide" id="mdEventsBand" visible="false" position="10px -10px" size="1130px 344px">
                             <Text profile="RF_SectionTitle" id="mdEventsTitle" position="10px -6px" size="700px 22px" text=""/>
                             <Text profile="RF_ColHeader" id="mdEvColName" position="10px -36px" size="420px 20px" text=""/>
                             <Text profile="RF_ColHeader" id="mdEvColIntensity" position="450px -36px" size="220px 20px" text=""/>
@@ -752,12 +809,12 @@
                             <Text profile="RF_TreatTargetLine" id="mdEvMore" position="10px -240px" size="1100px 20px" text=""/>
                             <Text profile="RF_HintText" id="mdEventsEmpty" position="10px -64px" size="1100px 44px"
                                   textMaxNumLines="2" visible="false" text=""/>
-            <Button profile="buttonActivate" id="mdOpenMarketBtnEvents" position="770px -280px" size="360px 36px"
+            <Button profile="buttonActivate" id="mdOpenMarketBtnEvents" position="770px -280px" size="350px 36px"
                     onClick="onClickMdOpenMarket"/>
                         </GuiElement>
 
                         <!-- Page C — Contracts (read-only fixed rows). -->
-                        <GuiElement id="mdContractsBand" visible="false" position="0px 0px" size="100% 100%">
+                        <GuiElement profile="RF_EscCardFrameWide" id="mdContractsBand" visible="false" position="10px -10px" size="1130px 344px">
                             <Text profile="RF_SectionTitle" id="mdContractsTitle" position="10px -6px" size="900px 22px" text=""/>
                             <Text profile="RF_ColHeader" id="mdCtColCrop" position="10px -36px" size="280px 20px" text=""/>
                             <Text profile="RF_ColHeader" id="mdCtColQty" position="300px -36px" size="220px 20px" text=""/>
@@ -786,7 +843,7 @@
                             <Text profile="RF_TreatTargetLine" id="mdCtMore" position="10px -212px" size="1100px 20px" text=""/>
                             <Text profile="RF_HintText" id="mdContractsEmpty" position="10px -64px" size="1100px 44px"
                                   textMaxNumLines="2" visible="false" text=""/>
-            <Button profile="buttonActivate" id="mdOpenMarketBtnContracts" position="770px -280px" size="360px 36px"
+            <Button profile="buttonActivate" id="mdOpenMarketBtnContracts" position="770px -280px" size="350px 36px"
                     onClick="onClickMdOpenMarket"/>
                         </GuiElement>
                     </GuiElement>


### PR DESCRIPTION
## Summary
- Esc-only shared-door freeze: widen Soil PRODUCTS card to 620x248 so PRODUCTS–ROTATION gutters match the 10px family (TREATMENT/ROTATION footprints unchanged).
- Tax only: Status densify FAILFIX (literal GuiUtils reassert every onShow; densify gone).
- Branched clean from live `development`. No `.local/share-staging`, no zip, no gameplay ride-alongs.

## Test plan
- [ ] Esc → RF → Soil: even gaps between the three bottom cards
- [ ] Esc → RF → Tax: Status lines inside the white frame
- [ ] Other RF Esc pages unchanged in behaviour
- [ ] No UTF-8 BOM / UTF-16 on touched files

Replaces the earlier oversized Esc WIP PRs (Sasha CHANGES_REQUESTED on Soil/SCS for deleted shipped APIs / undisclosed pump activatable).